### PR TITLE
Minimal numpy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
-os:
-    - osx
-    - linux
-osx_image:  xcode12.2
-python:
-    - "3.7"
-    - "3.8"
-    - "3.9"
+language: python
+matrix:
+    include:
+        - name: "Python 3.7,8,9 on Xenial Linux"
+          python: 
+            - "3.7"
+            - "3.8"
+            - "3.9"
+        - name: "Python 3.7 on macOS"
+          os: osx
+          osx_image: xcode12.2
+          language: generic
+          env: PYENV_VERSION=3.7.5
+        - name: "Python 3.8 on macOS"
+          os: osx
+          osx_image: xcode12.2
+          language: generic
+          env: PYENV_VERSION=3.8.0
+        - name: "Python 3.9 on macOS"
+          os: osx
+          osx_image: xcode12.2
+          language: generic
+          env: PYENV_VERSION=3.9.0
 install: 
     - python --version
     - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ matrix:
           python: 3.8 
         - name: "Python 3.9 on Xenial Linux"
           python: 3.9 
-        - name: "Python 3.7 on macOS"
+        - name: "Python 3.7.5 on macOS"
           os: osx
           osx_image: xcode10.2
           language: generic
-          env: PYENV_VERSION=3.7.7
-        - name: "Python 3.8 on macOS"
+          env: PYENV_VERSION=3.7.5
+        - name: "Python 3.7.7 on macOS"
           os: osx
           osx_image: xcode11.7
           language: generic
-          env: PYENV_VERSION=3.8.0
+          env: PYENV_VERSION=3.7.7
         - name: "Python 3.9 on macOS"
           os: osx
           osx_image: xcode12.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 matrix:
     include:
-        - name: "Python 3.7,8,9 on Xenial Linux"
-          python: 
-            - "3.7"
-            - "3.8"
-            - "3.9"
+        - name: "Python 3.7 on Xenial Linux"
+          python: 3.7 
+        - name: "Python 3.8 on Xenial Linux"
+          python: 3.8 
+        - name: "Python 3.9 on Xenial Linux"
+          python: 3.9 
         - name: "Python 3.7 on macOS"
           os: osx
           osx_image: xcode12.2
@@ -23,9 +24,10 @@ matrix:
           env: PYENV_VERSION=3.9.0
 install: 
     - python --version
-    - pip install -U pip
-    - pip install -r requirements.txt
-    - pip install .
+    - python3 --version
+    - pip3 install -U pip
+    - pip3 install -r requirements.txt
+    - pip3 install .
 script:
     - coverage run -m pytest tests/
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           env: PYENV_VERSION=3.7.7
         - name: "Python 3.8 on macOS"
           os: osx
-          osx_image: xcode11.3
+          osx_image: xcode11.7
           language: generic
           env: PYENV_VERSION=3.8.0
         - name: "Python 3.9 on macOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ os:
     - linux
 osx_image:  xcode12.2
 python:
-    - "2.7"
     - "3.7"
+    - "3.8"
+    - "3.9"
 install: 
     - pip install -r requirements.txt
     - pip install pyoscode==1.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.8"
     - "3.9"
 install: 
+    - python --version
     - pip install -U pip
     - pip install -r requirements.txt
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
           os: osx
           osx_image: xcode10.2
           language: generic
-          env: PYENV_VERSION=3.7.5
+          env: PYENV_VERSION=3.7.7
         - name: "Python 3.8 on macOS"
           os: osx
-          osx_image: xcode11.2
+          osx_image: xcode11.3
           language: generic
           env: PYENV_VERSION=3.8.0
         - name: "Python 3.9 on macOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ python:
     - "3.8"
     - "3.9"
 install: 
+    - pip install -U pip
     - pip install -r requirements.txt
-    - pip install pyoscode==1.0.2
+    - pip install .
 script:
     - coverage run -m pytest tests/
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
           python: 3.9 
         - name: "Python 3.7 on macOS"
           os: osx
-          osx_image: xcode12.2
+          osx_image: xcode10.2
           language: generic
           env: PYENV_VERSION=3.7.5
         - name: "Python 3.8 on macOS"
           os: osx
-          osx_image: xcode12.2
+          osx_image: xcode11.2
           language: generic
           env: PYENV_VERSION=3.8.0
         - name: "Python 3.9 on macOS"

--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,8 @@ devs of `exhale <https://pypi.org/project/exhale/>`__ for making the beautiful C
 Changelog
 ---------
 
+- 1.0.4:
+    - set minimally required numpy version: numpy>=1.20.0
 - 1.0.3: 
     - paper accepted to JOSS
 - 1.0.2:

--- a/README.rst
+++ b/README.rst
@@ -260,6 +260,7 @@ Changelog
 
 - 1.0.4:
     - set minimally required numpy version: numpy>=1.20.0
+    - drop Python 2.7 support, instead support 3.8 and 3.9 in addition to 3.7
 - 1.0.3: 
     - paper accepted to JOSS
 - 1.0.2:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.20.0
 scipy
 matplotlib
 pytest

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ pyoscode_module = Extension(
 
 setup(
     name="pyoscode",
-    version="1.0.2",
+    version="1.0.4",
     description=readme(short=True),
     long_description=readme(),
     url="https://github.com/fruzsinaagocs/oscode",


### PR DESCRIPTION
* Change `requirements.txt` to require `numpy>=1.20.0`.
* drop Python 2.7 support and support Python 3.8 and 3.9 instead 
  (note that most major packages like numpy and scipy have dropped Python 2.7 support now...)

fixes #8 