### PR TITLE
Extended `de_system` class to allow for additional parameters to be passed to the `w` and `g` functions

### DIFF
--- a/examples/burst.cpp
+++ b/examples/burst.cpp
@@ -42,7 +42,7 @@ std::complex<double> dxburst(double t){
     std::complex<double>(-n,t)*std::sin(n*std::atan(t))); 
 };
 
-/** \brif Routine to call oscode to solve an example ODE, to illustrate basic
+/** \brief Routine to call oscode to solve an example ODE, to illustrate basic
  * functionality.
  *
  * Routine to call oscode to solve the example ODE (the "burst" equation):

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -11,7 +11,8 @@ class de_system
         template<typename X, typename Y, typename Z, typename X_it>de_system(X
         &ts, Y &ws, Z &gs, X_it x_it, int size, bool isglogw=false, bool
         islogg=false, int even=0, int check_grid=0);
-        de_system(std::complex<double> (*w)(double), std::complex<double> (*g)(double));
+        de_system(std::complex<double> (*)(double, void*), std::complex<double> (*)(double, void*), void*);
+        de_system(std::complex<double> (*)(double), std::complex<double> (*)(double));
         de_system();
         std::function<std::complex<double>(double)> w;
         std::function<std::complex<double>(double)> g;
@@ -85,6 +86,17 @@ islogg, int even, int check_grid){
 
 /** Constructor for the case when the frequency and damping terms have been
  * defined as functions
+ */
+de_system::de_system(std::complex<double> (*W)(double, void*),
+std::complex<double> (*G)(double, void*), void *p){
+    
+    is_interpolated = 0;
+    w = [W, p](double x){ return W(x, p); };
+    g = [G, p](double x){ return G(x, p); };
+};
+
+/** Constructor for the case when the frequency and damping terms have been
+ * defined as functions (and there are no additional parameters that the function might need)
  */
 de_system::de_system(std::complex<double> (*W)(double), std::complex<double> (*G)(double)){
     


### PR DESCRIPTION
I added an overloaded constructor and tested it with the `burst.cpp` example. Can add a version of the test to the original example or update it if desired.