### PR TITLE
Issue15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,9 +179,10 @@ C++
 To compile and run:
 
 .. code:: bash
-
-    g++ -g -Wall -std=c++11 -c -o burst.o burst.cpp
-    g++ -g -Wall -std=c++11 -o burst burst.o
+    
+    cd examples/
+    g++ -I../include/ -g -Wall -std=c++11 -c -o burst.o burst.cpp
+    g++ -I../include/ -g -Wall -std=c++11 -o burst burst.o
     ./burst
 
 
@@ -258,6 +259,13 @@ devs of `exhale <https://pypi.org/project/exhale/>`__ for making the beautiful C
 Changelog
 ---------
 
+- 1.0.6:
+    - Fix issues related to dense output not being correctly generated, e.g. when timepoints at which dense output was asked for are in descending order, etc. 
+- 1.0.5:
+    - Fixes related to dense output generation
+    - Support for w, g to be given as class member functions in C++
+    - Switched to GH actions for continuous integration, and fixed code such that unit tests would run again
+    - Minor tweaks
 - 1.0.4:
     - set minimally required numpy version: numpy>=1.20.0
     - drop Python 2.7 support, instead support 3.8 and 3.9 in addition to 3.7

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -221,13 +221,18 @@ a_tol, double h_0, const char* full_output){
         return;
     }
 
-    // Dense output checks: 
+    // Dense output preprocessing: sort and reverse if necessary
     int dosize = do_times.size();
     dotimes.resize(dosize);
     dosol.resize(dosize);
     dodsol.resize(dosize);
-    auto doit = do_times.begin();
 
+    // Sort
+    auto do_times_copy = do_times;
+    std::sort(do_times_copy.begin(), do_times_copy.end());
+    auto doit = do_times_copy.begin();
+
+    // Reverse if integrating backwards
     if((de_sys_->is_interpolated == 1 and de_sys_->Winterp.sign_ == 1) or (de_sys_->is_interpolated == 0 and sign == 1)){
         for(auto it=dotimes.begin(); it!=dotimes.end(); it++){
             *it = *doit;

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -227,23 +227,18 @@ a_tol, double h_0, const char* full_output){
     dosol.resize(dosize);
     dodsol.resize(dosize);
 
-    // Sort
-    auto do_times_copy = do_times;
-    std::sort(do_times_copy.begin(), do_times_copy.end());
-    auto doit = do_times_copy.begin();
-
-    // Reverse if integrating backwards
-    if((de_sys_->is_interpolated == 1 and de_sys_->Winterp.sign_ == 1) or (de_sys_->is_interpolated == 0 and sign == 1)){
-        for(auto it=dotimes.begin(); it!=dotimes.end(); it++){
-            *it = *doit;
-            doit++;
-        }
+    // Copy dense output points to list
+    auto doit = do_times.begin();
+    for(auto it=dotimes.begin(); it!=dotimes.end(); it++){
+        *it = *doit;
+        doit++;
     }
-    else{
-        for(auto it=dotimes.rbegin(); it!=dotimes.rend(); ++it){
-            *it = *doit;
-            ++doit;
-        }
+    // Sort to ensure ascending order
+    dotimes.sort();
+
+    // Reverse if necessary
+    if((de_sys_->is_interpolated == 1 and de_sys_->Winterp.sign_ == 0) or (de_sys_->is_interpolated == 0 and sign == 0)){
+        dotimes.reverse();
     }
 
     dotit = dotimes.begin();

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -60,7 +60,7 @@ class Solution
     /** List to contain the "type" of each step (RK/WKB) taken internally by the
      * solver after a run */
     std::list<bool> wkbs;
-    /** Lists to contain the timepoints at which dense output was evaluated */
+    /** Lists to contain the timepoints at which dense output was evaluated. This list will always be sorted in ascending order (with possible duplicates), regardless of the order the timepoints were specified upon input. */
     std::list<double> dotimes;
     /** Lists to contain the dense output of the solution and its derivative */
     std::list<std::complex<double>> dosol, dodsol;
@@ -166,7 +166,7 @@ a_tol, double h_0, const char* full_output){
  * the start of the integration range
  * @param[in] t_i start of integration range
  * @param[in] t_f end of integration range
- * @param[in] do_times timepoints at which dense output is to be produced
+ * @param[in] do_times timepoints at which dense output is to be produced. Doesn't need to be sorted, and duplicated are allowed.
  * @param[in] o order of WKB approximation to be used
  * @param[in] r_tol (local) relative tolerance
  * @param[in] a_tol (local) absolute tolerance 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ pyoscode_module = Extension(
 
 setup(
     name="pyoscode",
-    version="1.0.5",
+    version="1.0.6",
     description=readme(short=True),
     long_description=readme(),
     url="https://github.com/fruzsinaagocs/oscode",


### PR DESCRIPTION
# Description

This PR adds code that sorts the sequence of points at which dense output is requested (dense output points hereafter). This increases robustness in general, and fixes issue #15, where the dense output was filled up with zeros when the dense output points were in descending order *and* the integration direction was backwards (`t_i > t_f`). A side effect is that in the latter case, the dense output points get sorted in ascending order, reversed, and then reversed again before output. This means extra effort (but negligible compared to generating dense output) and that the dense output points upon output will always be in sorted, ascending order regardless of the order in which they were input.

Fixes #15 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (`pytest`)
- [x] Update version number
- [x] Update documentation: add warning about ordering of dense output points upon output.
