### PR TITLE
run clang-format on header files

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-version: 2
+version: 2.0.1
 
 # Build documentation in the docs/ directory with Sphinx
 #sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
-version: 2.0.1
+version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 #sphinx:

--- a/include/interpolator.hpp
+++ b/include/interpolator.hpp
@@ -1,149 +1,142 @@
 #pragma once
-#include <iterator>
 #include <cmath>
 #include <complex>
+#include <iterator>
 
-template<typename X = double*, typename Y= std::complex<double>*, typename InputIt_x= double*>
-struct LinearInterpolator{
+template <typename X = double *, typename Y = std::complex<double> *,
+          typename InputIt_x = double *>
+struct LinearInterpolator {
 
-    public:
-        int sign_; // denotes direction of integration
-        double xstart, dx;
-        X x_; // array of indep. variable
-        Y y_; // array of dep. variable
-        int even_; // Bool, true for evenly spaced grids
-        InputIt_x x_lower_bound, x_upper_bound;
-        InputIt_x x_lower_it, x_upper_it, x0_it;
-        double x_lower, x_upper, h; 
-        std::complex<double> y_lower, y_upper;
-        
+public:
+  int sign_; // denotes direction of integration
+  double xstart, dx;
+  X x_;      // array of indep. variable
+  Y y_;      // array of dep. variable
+  int even_; // Bool, true for evenly spaced grids
+  InputIt_x x_lower_bound, x_upper_bound;
+  InputIt_x x_lower_it, x_upper_it, x0_it;
+  double x_lower, x_upper, h;
+  std::complex<double> y_lower, y_upper;
 
-    LinearInterpolator(){
-        // Default constructor
+  LinearInterpolator() {
+    // Default constructor
+  }
+
+  LinearInterpolator(X x, Y y, int even) {
+    // Constructor of struct, sets struct members
+
+    even_ = even;
+    if (even == 1) {
+      x_ = x;
+      y_ = y;
+      xstart = x[0];
+      dx = x[1] - x[0];
+    } else {
+      x_ = x;
+      y_ = y;
     }
+  }
 
-    LinearInterpolator(X x, Y y, int even){
-        // Constructor of struct, sets struct members
+  void set_interp_start(InputIt_x x_start) {
+    // Sets iterator pointing to first element of time-array
+    x0_it = x_start;
+  }
 
-        even_ = even;
-        if(even == 1){
-            x_ = x;
-            y_ = y;
-            xstart = x[0];
-            dx = x[1]-x[0];
+  void set_interp_bounds(InputIt_x lower_it, InputIt_x upper_it) {
+    // Sets iterators for lower and upper bounds within which search for
+    // nearest neighbours is performed for interpolation.
+    x_lower_bound = lower_it;
+    x_upper_bound = upper_it;
+  }
+
+  void update_interp_bounds() {
+    if (even_ == 0 && sign_ == 1) {
+      x_lower_bound = x_upper_it;
+    } else if (even_ == 0 && sign_ == 0) {
+      x_upper_bound = x_lower_it;
+    }
+  }
+
+  void update_interp_bounds_reverse() { x_upper_bound = x_lower_it; }
+
+  std::complex<double> operator()(double x) {
+    // Does linear interpolation
+    std::complex<double> result;
+
+    if (even_ == 1) {
+      int i = int((x - xstart) / dx);
+      std::complex<double> y0 = y_[i];
+      std::complex<double> y1 = y_[i + 1];
+      result = (y0 + (y1 - y0) * (x - xstart - dx * i) / dx);
+    } else {
+
+      x_upper_it = std::upper_bound(x_lower_bound, x_upper_bound, x);
+      x_lower_it = x_upper_it - 1;
+      x_lower = *x_lower_it;
+      x_upper = *x_upper_it;
+      y_lower = y_[(x_lower_it - x0_it)];
+      y_upper = y_[(x_upper_it - x0_it)];
+      result = (y_lower * (x_upper - x) + y_upper * (x - x_lower)) /
+               (x_upper - x_lower);
+    }
+    return result;
+  }
+
+  std::complex<double> expit(double x) {
+    // Does linear interpolation when the input is ln()-d
+
+    std::complex<double> result;
+    if (even_ == 1) {
+      int i = int((x - xstart) / dx);
+      std::complex<double> y0 = y_[i];
+      std::complex<double> y1 = y_[i + 1];
+      result = std::exp(y0 + (y1 - y0) * (x - xstart - dx * i) / dx);
+    } else {
+      x_upper_it = std::upper_bound(x_lower_bound, x_upper_bound, x);
+      x_lower_it = x_upper_it - 1;
+      x_lower = *x_lower_it;
+      x_upper = *x_upper_it;
+      y_lower = y_[(x_lower_it - x0_it)];
+      y_upper = y_[(x_upper_it - x0_it)];
+      result = (y_lower * (x_upper - x) + y_upper * (x - x_lower)) /
+               (x_upper - x_lower);
+      result = std::exp(result);
+    }
+    return result;
+  }
+
+  int check_grid_fineness(int N) {
+
+    int success = 1;
+    std::complex<double> y0, y1, yprev, ynext;
+    double x0, xprev, xnext;
+    double err;
+
+    // Check grid fineness here
+    for (int i = 2; i < N; i += 2) {
+      if (even_ == 1) {
+        y0 = y_[i - 1];
+        y1 = 0.5 * (y_[i] + y_[i - 2]);
+        err = std::abs((y1 - y0) / y0);
+        if (err > 2e-5) {
+          success = 0;
+          break;
         }
-        else{
-            x_ = x;
-            y_ = y;
+      } else {
+        y0 = y_[i - 1];
+        x0 = x_[i - 1];
+        xprev = x_[i - 2];
+        xnext = x_[i];
+        yprev = y_[i - 2];
+        ynext = y_[i];
+        y1 = (yprev * (xnext - x0) + ynext * (x0 - xprev)) / (xnext - xprev);
+        err = std::abs((y1 - y0) / y0);
+        if (err > 2e-5) {
+          success = 0;
+          break;
         }
+      }
     }
-
-    void set_interp_start(InputIt_x x_start){
-        // Sets iterator pointing to first element of time-array
-        x0_it = x_start; 
-    }
-    
-    void set_interp_bounds(InputIt_x lower_it, InputIt_x upper_it){
-        // Sets iterators for lower and upper bounds within which search for
-        // nearest neighbours is performed for interpolation. 
-        x_lower_bound = lower_it;
-        x_upper_bound = upper_it;
-    }
-
-    void update_interp_bounds(){
-        if(even_ == 0 && sign_ == 1){
-            x_lower_bound = x_upper_it;
-        }
-        else if(even_ == 0 && sign_ == 0){
-            x_upper_bound = x_lower_it;
-        }
-    }
-
-    void update_interp_bounds_reverse(){
-        x_upper_bound = x_lower_it;
-    }
-
-    std::complex<double> operator() (double x)  {
-        // Does linear interpolation 
-        std::complex<double> result; 
-        
-        if(even_ == 1){
-            int i=int((x-xstart)/dx);
-            std::complex<double> y0=y_[i];
-            std::complex<double> y1=y_[i+1];
-            result = (y0+(y1-y0)*(x-xstart-dx*i)/dx);
-        }
-        else{
-
-            x_upper_it = std::upper_bound(x_lower_bound, x_upper_bound, x);
-            x_lower_it = x_upper_it-1; 
-            x_lower = *x_lower_it;
-            x_upper = *x_upper_it;
-            y_lower = y_[(x_lower_it - x0_it)];
-            y_upper = y_[(x_upper_it - x0_it)];
-            result = (y_lower*(x_upper-x) + y_upper*(x-x_lower))/(x_upper - x_lower);
-        }
-        return result;
-    }
-
-    std::complex<double> expit (double x)  {
-        // Does linear interpolation when the input is ln()-d
-        
-        std::complex<double> result;
-        if(even_ == 1){
-            int i=int((x-xstart)/dx);
-            std::complex<double> y0=y_[i];
-            std::complex<double> y1=y_[i+1];
-            result = std::exp(y0+(y1-y0)*(x-xstart-dx*i)/dx);
-        }
-        else{
-            x_upper_it = std::upper_bound(x_lower_bound, x_upper_bound, x);
-            x_lower_it = x_upper_it-1; 
-            x_lower = *x_lower_it;
-            x_upper = *x_upper_it;
-            y_lower = y_[(x_lower_it - x0_it)];
-            y_upper = y_[(x_upper_it - x0_it)];
-            result = (y_lower*(x_upper-x) + y_upper*(x-x_lower))/(x_upper - x_lower);
-            result = std::exp(result);
-            }
-        return result;
-    }
-
-    int check_grid_fineness(int N){
-    
-        int success = 1;
-        std::complex<double> y0, y1, yprev, ynext;
-        double x0, xprev, xnext;
-        double err;
-        
-        // Check grid fineness here
-        for(int i=2; i<N; i+=2){
-            if(even_ == 1){
-                y0 = y_[i-1];
-                y1 = 0.5*(y_[i]+y_[i-2]);
-                err = std::abs((y1-y0)/y0);
-                if(err > 2e-5){
-                    success = 0;
-                    break;
-                }
-            }
-            else{
-                y0 = y_[i-1];
-                x0 = x_[i-1];
-                xprev = x_[i-2];
-                xnext = x_[i];
-                yprev = y_[i-2];
-                ynext = y_[i];
-                y1 = (yprev*(xnext - x0) + ynext*(x0 - xprev))/(xnext - xprev);
-                err = std::abs((y1-y0)/y0);
-                if(err > 2e-5){
-                    success = 0;
-                    break;
-                }
-            }
-        }
-        return success;
-    }
-   
+    return success;
+  }
 };
-

--- a/include/rksolver.hpp
+++ b/include/rksolver.hpp
@@ -1,5 +1,9 @@
 #pragma once
-#include "system.hpp"
+#include <system.hpp>
+#include <Eigen/Dense>
+#include <complex>
+#include <functional>
+#include <list>
 
 /** Class that defines a 4 and 5th order Runge-Kutta method.
  *

--- a/include/rksolver.hpp
+++ b/include/rksolver.hpp
@@ -7,113 +7,123 @@
  * Runge-Kutta formula based on the nodes used in 5th and 6th order
  * Gauss-Lobatto integration, as detailed in [1].
  *
- * [1] Agocs, F. J., et al. “Efficient Method for Solving Highly Oscillatory Ordinary Differential Equations with Applications to Physical Systems.” Physical Review Research, vol. 2, no. 1, 2020, doi:10.1103/physrevresearch.2.013030. 
+ * [1] Agocs, F. J., et al. “Efficient Method for Solving Highly Oscillatory
+ * Ordinary Differential Equations with Applications to Physical Systems.”
+ * Physical Review Research, vol. 2, no. 1, 2020,
+ * doi:10.1103/physrevresearch.2.013030.
  */
-class RKSolver
-{
-    private: 
-    // Frequency and friction term
-    std::function<std::complex<double>(double)> w;
-    std::function<std::complex<double>(double)> g;
-    
+class RKSolver {
+private:
+  // Frequency and friction term
+  std::function<std::complex<double>(double)> w;
+  std::function<std::complex<double>(double)> g;
 
-    // Butcher tablaus
-    Eigen::Matrix<double,5,5> butcher_a5;
-    Eigen::Matrix<double,3,3> butcher_a4;
-    Eigen::Matrix<double,6,1> butcher_b5, butcher_c5, dense_b5;
-    Eigen::Matrix<double,4,1> butcher_b4, butcher_c4;
+  // Butcher tablaus
+  Eigen::Matrix<double, 5, 5> butcher_a5;
+  Eigen::Matrix<double, 3, 3> butcher_a4;
+  Eigen::Matrix<double, 6, 1> butcher_b5, butcher_c5, dense_b5;
+  Eigen::Matrix<double, 4, 1> butcher_b4, butcher_c4;
 
-    // Current values of w, g
-    std::complex<double> wi, gi;
-   
-    public:
+  // Current values of w, g
+  std::complex<double> wi, gi;
 
-    /** Defines the ODE */
-    de_system *de_sys_;
+public:
+  /** Defines the ODE */
+  de_system *de_sys_;
 
-    /** Callable that gives the frequency term in the ODE at a given time */
-    //std::function<std::complex<double>(double)> w;
-    
-    // constructors
-    RKSolver();
-    RKSolver(de_system &de_sys);
-    // grid of ws, gs
-    /** 6 values of the frequency term per step, evaluated at the nodes of 6th
-     * order Gauss-Lobatto quadrature
-     */
-    Eigen::Matrix<std::complex<double>,6,1> ws;
-    /** 6 values of the friction term per step, evaluated at the nodes of 6th
-     * order Gauss-Lobatto quadrature
-     */
-    Eigen::Matrix<std::complex<double>,6,1> gs;
-    /** 5 values of the frequency term per step, evaluated at the nodes of 5th
-     * order Gauss-Lobatto quadrature
-     */
-    Eigen::Matrix<std::complex<double>,5,1> ws5;
-    /** 5 values of the friction term per step, evaluated at the nodes of 5th
-     * order Gauss-Lobatto quadrature
-     */
-    Eigen::Matrix<std::complex<double>,5,1> gs5;
+  /** Callable that gives the frequency term in the ODE at a given time */
+  // std::function<std::complex<double>(double)> w;
 
-    // single step function 
-    Eigen::Matrix<std::complex<double>,2,2> step(std::complex<double>, std::complex<double>, double, double);
-    // ODE to solve
-    Eigen::Matrix<std::complex<double>,1,2> f(double t, const Eigen::Matrix<std::complex<double>,1,2> &y);  
-    // For dense output
-    Eigen::Matrix<std::complex<double>,6,2> k5;
-    Eigen::Matrix<std::complex<double>,1,2> dense_point(std::complex<double> x, std::complex<double> dx, const Eigen::Matrix<std::complex<double>,6,2> &k5);
-    Eigen::Matrix<std::complex<double>,7,2> k_dense;
-    Eigen::Matrix<double,7,4> P_dense;
-    void dense_step(double t0, double h0, std::complex<double> y0, std::complex<double> dy0, const std::list<double> &dots, std::list<std::complex<double>> &doxs, std::list<std::complex<double>> &dodxs);
-    // Experimental continuous representation of solution
-    Eigen::Matrix<std::complex<double>,7,1> x_vdm;
+  // constructors
+  RKSolver();
+  RKSolver(de_system &de_sys);
+  // grid of ws, gs
+  /** 6 values of the frequency term per step, evaluated at the nodes of 6th
+   * order Gauss-Lobatto quadrature
+   */
+  Eigen::Matrix<std::complex<double>, 6, 1> ws;
+  /** 6 values of the friction term per step, evaluated at the nodes of 6th
+   * order Gauss-Lobatto quadrature
+   */
+  Eigen::Matrix<std::complex<double>, 6, 1> gs;
+  /** 5 values of the frequency term per step, evaluated at the nodes of 5th
+   * order Gauss-Lobatto quadrature
+   */
+  Eigen::Matrix<std::complex<double>, 5, 1> ws5;
+  /** 5 values of the friction term per step, evaluated at the nodes of 5th
+   * order Gauss-Lobatto quadrature
+   */
+  Eigen::Matrix<std::complex<double>, 5, 1> gs5;
 
+  // single step function
+  Eigen::Matrix<std::complex<double>, 2, 2>
+  step(std::complex<double>, std::complex<double>, double, double);
+  // ODE to solve
+  Eigen::Matrix<std::complex<double>, 1, 2>
+  f(double t, const Eigen::Matrix<std::complex<double>, 1, 2> &y);
+  // For dense output
+  Eigen::Matrix<std::complex<double>, 6, 2> k5;
+  Eigen::Matrix<std::complex<double>, 1, 2>
+  dense_point(std::complex<double> x, std::complex<double> dx,
+              const Eigen::Matrix<std::complex<double>, 6, 2> &k5);
+  Eigen::Matrix<std::complex<double>, 7, 2> k_dense;
+  Eigen::Matrix<double, 7, 4> P_dense;
+  void dense_step(double t0, double h0, std::complex<double> y0,
+                  std::complex<double> dy0, const std::list<double> &dots,
+                  std::list<std::complex<double>> &doxs,
+                  std::list<std::complex<double>> &dodxs);
+  // Experimental continuous representation of solution
+  Eigen::Matrix<std::complex<double>, 7, 1> x_vdm;
 };
 
 /** Default constructor. */
-RKSolver::RKSolver(){
-};
+RKSolver::RKSolver(){};
 
 /** Constructor for the RKSolver class. It sets up the Butcher tableaus for the
  * two Runge-Kutta methods (4th and 5th order) used.
  *
  * @param de_sys[in] the system of first-order equations defining the
- * second-order ODE to solve. 
+ * second-order ODE to solve.
  */
-RKSolver::RKSolver(de_system &de_sys){
+RKSolver::RKSolver(de_system &de_sys) {
 
-   
-    de_sys_ = &de_sys;
-    if(de_sys_->is_interpolated == 0){
-        w = de_sys.w;
-        g = de_sys.g;
-    }
-    // Set Butcher tableaus
-    RKSolver::butcher_a5 << 0.1174723380352676535740,0,0,0,0,
-                 -0.1862479800651504276304,0.5436322218248278794734,0,0,0,
-                 -0.6064303885508280518989,1,0.2490461467911506000559,0,0,
-                 2.899356540015731406420,-4.368525611566240669139,2.133806714786316899991,0.2178900187289247091542,0,
-                 18.67996349995727204273,-28.85057783973131956546,10.72053408420926869789,1.414741756508049078612,-0.9646615009432702537787;
-	RKSolver::butcher_a4 << 0.172673164646011428100,0,0,
-                -1.568317088384971429762,2.395643923738960001662,0,
-                -8.769507466172720011410,10.97821961869480000808,-1.208712152522079996671;
-	RKSolver::butcher_b5 << 0.1127557227351729739820,0,0.5065579732655351768382,0.04830040376995117617928,0.3784749562978469803166,-0.04608905606850630731611;
-	RKSolver::dense_b5 << 0.2089555395,0.,0.7699501023,0.009438629906,-0.003746982422,0.01540271068; 
-	RKSolver::butcher_c5 << 0,0.117472338035267653574,0.357384241759677451843,0.642615758240322548157,0.882527661964732346426,1;
-	RKSolver::butcher_b4 << -0.08333333333333333333558,0.5833333333333333333357,0.5833333333333333333356,-0.08333333333333333333558;
-	RKSolver::butcher_c4 << 0,0.172673164646011428100,0.827326835353988571900,1;
-    RKSolver::P_dense << 1.        , -2.48711376,  2.42525041, -0.82538093,
-                         0.        ,  0.        ,  0.        ,  0.,
-                         0.        ,  3.78546138, -5.54469086,  2.26578746,
-                         0.        , -0.27734213,  0.74788587, -0.42224334,
-                         0.        , -2.94848704,  7.41087391, -4.08391191,
-                         0.        ,  0.50817346, -1.20070313,  0.64644062,
-                         0.        ,  1.4193081 , -3.8386162 ,  2.4193081;
-
+  de_sys_ = &de_sys;
+  if (de_sys_->is_interpolated == 0) {
+    w = de_sys.w;
+    g = de_sys.g;
+  }
+  // Set Butcher tableaus
+  RKSolver::butcher_a5 << 0.1174723380352676535740, 0, 0, 0, 0,
+      -0.1862479800651504276304, 0.5436322218248278794734, 0, 0, 0,
+      -0.6064303885508280518989, 1, 0.2490461467911506000559, 0, 0,
+      2.899356540015731406420, -4.368525611566240669139,
+      2.133806714786316899991, 0.2178900187289247091542, 0,
+      18.67996349995727204273, -28.85057783973131956546,
+      10.72053408420926869789, 1.414741756508049078612,
+      -0.9646615009432702537787;
+  RKSolver::butcher_a4 << 0.172673164646011428100, 0, 0,
+      -1.568317088384971429762, 2.395643923738960001662, 0,
+      -8.769507466172720011410, 10.97821961869480000808,
+      -1.208712152522079996671;
+  RKSolver::butcher_b5 << 0.1127557227351729739820, 0, 0.5065579732655351768382,
+      0.04830040376995117617928, 0.3784749562978469803166,
+      -0.04608905606850630731611;
+  RKSolver::dense_b5 << 0.2089555395, 0., 0.7699501023, 0.009438629906,
+      -0.003746982422, 0.01540271068;
+  RKSolver::butcher_c5 << 0, 0.117472338035267653574, 0.357384241759677451843,
+      0.642615758240322548157, 0.882527661964732346426, 1;
+  RKSolver::butcher_b4 << -0.08333333333333333333558, 0.5833333333333333333357,
+      0.5833333333333333333356, -0.08333333333333333333558;
+  RKSolver::butcher_c4 << 0, 0.172673164646011428100, 0.827326835353988571900,
+      1;
+  RKSolver::P_dense << 1., -2.48711376, 2.42525041, -0.82538093, 0., 0., 0., 0.,
+      0., 3.78546138, -5.54469086, 2.26578746, 0., -0.27734213, 0.74788587,
+      -0.42224334, 0., -2.94848704, 7.41087391, -4.08391191, 0., 0.50817346,
+      -1.20070313, 0.64644062, 0., 1.4193081, -3.8386162, 2.4193081;
 };
 
 /** Turns the second-order ODE into a system of first-order ODEs as follows:
- * 
+ *
  * \f[ y = [x, \dot{x}], \f]
  * \f[ \dot{y[0]} = y[1], \f]
  * \f[ \dot{y[1]} = -\omega^2(t)y[0] -2\gamma(t)y[1]. \f]
@@ -122,26 +132,27 @@ RKSolver::RKSolver(de_system &de_sys){
  * @param y[in] vector of unknowns \f$ y = [x, \dot{x}] \f$
  * @returns a vector of the derivative of \f$ y \f$
  */
-Eigen::Matrix<std::complex<double>,1,2> RKSolver::f(double t, const Eigen::Matrix<std::complex<double>,1,2> &y){
-    
-//    std::cout << "Are we interpolating? " << de_sys_->is_interpolated << std::endl;
-    if(de_sys_->is_interpolated == 1){ 
-        if(de_sys_->islogw_)
-            wi = de_sys_->Winterp.expit(t);
-        else
-            wi = de_sys_->Winterp(t);
-        if(de_sys_->islogg_)
-            gi = de_sys_->Ginterp.expit(t);
-        else
-            gi = de_sys_->Ginterp(t);
-    }
-    else{
-        wi = w(t);
-        gi = g(t);
-    }
-    Eigen::Matrix<std::complex<double>,1,2> result;
-    result << y[1], -wi*wi*y[0]-2.0*gi*y[1];
-    return result;
+Eigen::Matrix<std::complex<double>, 1, 2>
+RKSolver::f(double t, const Eigen::Matrix<std::complex<double>, 1, 2> &y) {
+
+  //    std::cout << "Are we interpolating? " << de_sys_->is_interpolated <<
+  //    std::endl;
+  if (de_sys_->is_interpolated == 1) {
+    if (de_sys_->islogw_)
+      wi = de_sys_->Winterp.expit(t);
+    else
+      wi = de_sys_->Winterp(t);
+    if (de_sys_->islogg_)
+      gi = de_sys_->Ginterp.expit(t);
+    else
+      gi = de_sys_->Ginterp(t);
+  } else {
+    wi = w(t);
+    gi = g(t);
+  }
+  Eigen::Matrix<std::complex<double>, 1, 2> result;
+  result << y[1], -wi * wi * y[0] - 2.0 * gi * y[1];
+  return result;
 };
 
 /** Gives dense output at a single point during the step "for free", i.e. at no
@@ -149,128 +160,133 @@ Eigen::Matrix<std::complex<double>,1,2> RKSolver::f(double t, const Eigen::Matri
  * mid-way through the step at $\sigma \sim 0.59 \f$, where \f$ \sigma = 0 \f$
  * corresponds to the start, \f$ \sigma = 1 \f$ to the end of the step.
  */
-Eigen::Matrix<std::complex<double>,1,2> RKSolver::dense_point(std::complex<double> x, std::complex<double> dx, const Eigen::Matrix<std::complex<double>,6,2> &k5){
+Eigen::Matrix<std::complex<double>, 1, 2>
+RKSolver::dense_point(std::complex<double> x, std::complex<double> dx,
+                      const Eigen::Matrix<std::complex<double>, 6, 2> &k5) {
 
-    Eigen::Matrix<std::complex<double>,1,2> ydense;
-    ydense << x, dx;
-    for(int j=0; j<=5; j++)
-        ydense += 0.5866586817*dense_b5(j)*k5.row(j);       
-   return ydense; 
-    
+  Eigen::Matrix<std::complex<double>, 1, 2> ydense;
+  ydense << x, dx;
+  for (int j = 0; j <= 5; j++)
+    ydense += 0.5866586817 * dense_b5(j) * k5.row(j);
+  return ydense;
 };
 
 /** Calculated dense output at a given set of points during a step after a
- * successful Runge-Kutta type step. 
+ * successful Runge-Kutta type step.
  */
-void RKSolver::dense_step(double t0, double h0, std::complex<double> y0, std::complex<double> dy0, const std::list<double> &dots, std::list<std::complex<double>> &doxs, std::list<std::complex<double>> &dodxs){
-    
-    int docount = dots.size();
-    double h = h0;
-    double sig, sig2, sig3, sig4;
-    Eigen::Matrix<std::complex<double>,2,4> Q_dense = k_dense.transpose()*P_dense;
-    Eigen::MatrixXd  R_dense(4,docount);
-    Eigen::MatrixXcd Y_dense(2,docount);
-    
-    int colcount = 0;
-    for(auto it=dots.begin(); it!=dots.end(); it++){
-        // Transform intermediate points to be in (-1,1):
-        sig = (*it - t0)/h; 
-        sig2 = sig*sig;
-        sig3 = sig2*sig;
-        sig4 = sig3*sig;
-        R_dense.col(colcount) << sig, sig2, sig3, sig4;
-        colcount += 1;
-    }
-    Y_dense = Q_dense*R_dense;
-    auto it = doxs.begin();
-    auto dit = dodxs.begin();
-    for(int j=0; j<docount; j++){
-        *it = y0 + Y_dense.row(0)(j);
-        *dit = dy0 + Y_dense.row(1)(j);
-        it++;
-        dit++;
-    }
+void RKSolver::dense_step(double t0, double h0, std::complex<double> y0,
+                          std::complex<double> dy0,
+                          const std::list<double> &dots,
+                          std::list<std::complex<double>> &doxs,
+                          std::list<std::complex<double>> &dodxs) {
 
+  int docount = dots.size();
+  double h = h0;
+  double sig, sig2, sig3, sig4;
+  Eigen::Matrix<std::complex<double>, 2, 4> Q_dense =
+      k_dense.transpose() * P_dense;
+  Eigen::MatrixXd R_dense(4, docount);
+  Eigen::MatrixXcd Y_dense(2, docount);
+
+  int colcount = 0;
+  for (auto it = dots.begin(); it != dots.end(); it++) {
+    // Transform intermediate points to be in (-1,1):
+    sig = (*it - t0) / h;
+    sig2 = sig * sig;
+    sig3 = sig2 * sig;
+    sig4 = sig3 * sig;
+    R_dense.col(colcount) << sig, sig2, sig3, sig4;
+    colcount += 1;
+  }
+  Y_dense = Q_dense * R_dense;
+  auto it = doxs.begin();
+  auto dit = dodxs.begin();
+  for (int j = 0; j < docount; j++) {
+    *it = y0 + Y_dense.row(0)(j);
+    *dit = dy0 + Y_dense.row(1)(j);
+    it++;
+    dit++;
+  }
 };
 
 /** Computes a single Runge-Kutta type step, and returns the solution and its
- * local error estimate. 
+ * local error estimate.
  *
  *
  */
-Eigen::Matrix<std::complex<double>,2,2> RKSolver::step(std::complex<double> x0, std::complex<double> dx0, double t0, double h){
+Eigen::Matrix<std::complex<double>, 2, 2>
+RKSolver::step(std::complex<double> x0, std::complex<double> dx0, double t0,
+               double h) {
 
-    Eigen::Matrix<std::complex<double>,1,2> y0, y, y4, y5, delta, k5_i, k4_i;
-    y4 = Eigen::Matrix<std::complex<double>,1,2>::Zero();
-    y0 << x0, dx0;
-    y5 = y4;
-    // TODO: resizing of ws5, gs5, insertion
-    Eigen::Matrix<std::complex<double>,4,2> k4;
-    Eigen::Matrix<std::complex<double>,2,2> result;
-//    std::cout << "Set up RK step" << std::endl;
-    k5.row(0) = h*f(t0, y0);
-//    std::cout << "Asked for f" << std::endl;
-    ws(0) = wi;
-    gs(0) = gi;
-    for(int s=1; s<=5; s++){
-        y = y0;
-        for(int i=0; i<=(s-1); i++)
-            y += butcher_a5(s-1,i)*k5.row(i);
-        k5_i = h*f(t0 + butcher_c5(s)*h, y);
-        k5.row(s) = k5_i;
-        ws(s) = wi;
-        gs(s) = gi;
-    }
-    k4.row(0) = k5.row(0);
-    ws5(0) = ws(0);
-    gs5(0) = gs(0);
-    for(int s=1; s<=3; s++){
-       y = y0;
-       for(int i=0; i<=(s-1); i++)
-           y += butcher_a4(s-1,i)*k4.row(i);
-        k4_i = h*f(t0 + butcher_c4(s)*h, y);
-        k4.row(s) = k4_i;
-        ws5(s) = wi;
-        gs5(s) = gi;
-    }
-    for(int j=0; j<=5; j++)
-        y5 += butcher_b5(j)*k5.row(j);
-    for(int j=0; j<=3; j++)
-        y4 += butcher_b4(j)*k4.row(j);
-    delta = y5 - y4;
-    y5 += y0;
-    result << y5, delta;
-    // Add in missing w, g at t+h/2
-    ws5(4) = ws5(3);
-    ws5(3) = ws5(2);
-    gs5(4) = gs5(3);
-    gs5(3) = gs5(2);
-    if(de_sys_->is_interpolated == 1){
-        if(de_sys_->islogw_)
-            ws5(2) = de_sys_->Winterp.expit(t0+h/2);
-        else
-            ws5(2) = de_sys_->Winterp(t0+h/2);
-        if(de_sys_->islogg_)
-            gs5(2) = de_sys_->Ginterp.expit(t0+h/2);
-        else
-            gs5(2) = de_sys_->Ginterp(t0+h/2);
-    }
-    else{
-        ws5(2) = w(t0+h/2);
-        gs5(2) = g(t0+h/2);
-    }
+  Eigen::Matrix<std::complex<double>, 1, 2> y0, y, y4, y5, delta, k5_i, k4_i;
+  y4 = Eigen::Matrix<std::complex<double>, 1, 2>::Zero();
+  y0 << x0, dx0;
+  y5 = y4;
+  // TODO: resizing of ws5, gs5, insertion
+  Eigen::Matrix<std::complex<double>, 4, 2> k4;
+  Eigen::Matrix<std::complex<double>, 2, 2> result;
+  //    std::cout << "Set up RK step" << std::endl;
+  k5.row(0) = h * f(t0, y0);
+  //    std::cout << "Asked for f" << std::endl;
+  ws(0) = wi;
+  gs(0) = gi;
+  for (int s = 1; s <= 5; s++) {
+    y = y0;
+    for (int i = 0; i <= (s - 1); i++)
+      y += butcher_a5(s - 1, i) * k5.row(i);
+    k5_i = h * f(t0 + butcher_c5(s) * h, y);
+    k5.row(s) = k5_i;
+    ws(s) = wi;
+    gs(s) = gi;
+  }
+  k4.row(0) = k5.row(0);
+  ws5(0) = ws(0);
+  gs5(0) = gs(0);
+  for (int s = 1; s <= 3; s++) {
+    y = y0;
+    for (int i = 0; i <= (s - 1); i++)
+      y += butcher_a4(s - 1, i) * k4.row(i);
+    k4_i = h * f(t0 + butcher_c4(s) * h, y);
+    k4.row(s) = k4_i;
+    ws5(s) = wi;
+    gs5(s) = gi;
+  }
+  for (int j = 0; j <= 5; j++)
+    y5 += butcher_b5(j) * k5.row(j);
+  for (int j = 0; j <= 3; j++)
+    y4 += butcher_b4(j) * k4.row(j);
+  delta = y5 - y4;
+  y5 += y0;
+  result << y5, delta;
+  // Add in missing w, g at t+h/2
+  ws5(4) = ws5(3);
+  ws5(3) = ws5(2);
+  gs5(4) = gs5(3);
+  gs5(3) = gs5(2);
+  if (de_sys_->is_interpolated == 1) {
+    if (de_sys_->islogw_)
+      ws5(2) = de_sys_->Winterp.expit(t0 + h / 2);
+    else
+      ws5(2) = de_sys_->Winterp(t0 + h / 2);
+    if (de_sys_->islogg_)
+      gs5(2) = de_sys_->Ginterp.expit(t0 + h / 2);
+    else
+      gs5(2) = de_sys_->Ginterp(t0 + h / 2);
+  } else {
+    ws5(2) = w(t0 + h / 2);
+    gs5(2) = g(t0 + h / 2);
+  }
 
+  // Fill up k_dense matrix for dense output
+  for (int i = 0; i <= 5; i++)
+    k_dense.row(i) = k5.row(i);
+  k_dense.row(6) = h * f(t0 + h, y5);
 
-    // Fill up k_dense matrix for dense output
-    for(int i=0; i<=5; i++)
-        k_dense.row(i) = k5.row(i);
-    k_dense.row(6) = h*f(t0+h,y5);
+  // Experimental continuous output
+  Eigen::Matrix<std::complex<double>, 1, 4> Q_dense =
+      (k_dense.transpose() * P_dense).row(0);
+  x_vdm.tail(6) << Q_dense(0), Q_dense(1), Q_dense(2), Q_dense(3), 0.0, 0.0;
+  x_vdm(0) = x0;
 
-    // Experimental continuous output
-    Eigen::Matrix<std::complex<double>,1,4> Q_dense = (k_dense.transpose()*P_dense).row(0);
-    x_vdm.tail(6) << Q_dense(0), Q_dense(1), Q_dense(2), Q_dense(3), 0.0, 0.0;
-    x_vdm(0) = x0;
-
-    return result;
+  return result;
 };
-

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -1,75 +1,75 @@
 #pragma once
+#include "interpolator.hpp"
+#include "rksolver.hpp"
+#include "system.hpp"
+#include "wkbsolver.hpp"
 #include <Eigen/Dense>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <string>
-#include <iomanip>
-#include <limits>
 #include <vector>
-#include "interpolator.hpp"
-#include "system.hpp"
-#include "rksolver.hpp"
-#include "wkbsolver.hpp"
-
 
 /** A class to store all information related to a numerical solution run.  */
-class Solution
-{
-    private:
-    double t, tf, rtol, atol, h0;
-    std::complex<double> x, dx;
-    int order;
-    const char* fo;
-    WKBSolver * wkbsolver;
-    WKBSolver1 wkbsolver1;
-    WKBSolver2 wkbsolver2;
-    WKBSolver3 wkbsolver3;
-    /** A \a de_system object to carry information about the ODE. */
-    de_system *de_sys_;
-    /** These define the event at which integration finishes (currently: when tf
-     * is reached. */
-    double fend, fnext;
-    /** a boolean encoding the direction of integration: 1/True for forward. */
-    bool sign;
+class Solution {
+private:
+  double t, tf, rtol, atol, h0;
+  std::complex<double> x, dx;
+  int order;
+  const char *fo;
+  WKBSolver *wkbsolver;
+  WKBSolver1 wkbsolver1;
+  WKBSolver2 wkbsolver2;
+  WKBSolver3 wkbsolver3;
+  /** A \a de_system object to carry information about the ODE. */
+  de_system *de_sys_;
+  /** These define the event at which integration finishes (currently: when tf
+   * is reached. */
+  double fend, fnext;
+  /** a boolean encoding the direction of integration: 1/True for forward. */
+  bool sign;
 
-    public:
-    Solution(de_system &de_sys, std::complex<double> x0, std::complex<double>
-    dx0, double t_i, double t_f, int o=3, double r_tol=1e-4, double a_tol=0.0,
-    double h_0=1, const char* full_output="");
+public:
+  Solution(de_system &de_sys, std::complex<double> x0, std::complex<double> dx0,
+           double t_i, double t_f, int o = 3, double r_tol = 1e-4,
+           double a_tol = 0.0, double h_0 = 1, const char *full_output = "");
 
-    template<typename X = double> Solution(de_system &de_sys,
-    std::complex<double> x0, std::complex<double> dx0, double t_i, double t_f,
-    const X &do_times, int o=3, double r_tol=1e-4, double a_tol=0.0,
-    double h_0=1, const char* full_output="");
+  template <typename X = double>
+  Solution(de_system &de_sys, std::complex<double> x0, std::complex<double> dx0,
+           double t_i, double t_f, const X &do_times, int o = 3,
+           double r_tol = 1e-4, double a_tol = 0.0, double h_0 = 1,
+           const char *full_output = "");
 
-    void solve();
-    
-    /** Object to call RK steps */
-    RKSolver rksolver;
-    
-    /** Successful, total attempted, and successful WKB steps the solver took,
-     * respectively  */
-    int ssteps, totsteps, wkbsteps;
-    /** Lists to contain the solution and its derivative evaluated at internal
-     * points taken by the solver (i.e. not dense output) after a run */
-    std::list<std::complex<double>> sol, dsol;
-    /** List to contain the timepoints at which the solution and derivative are
-     * internally evaluated by the solver */
-    std::list<double> times;
-    /** List to contain the "type" of each step (RK/WKB) taken internally by the
-     * solver after a run */
-    std::list<bool> wkbs;
-    /** Lists to contain the timepoints at which dense output was evaluated. This list will always be sorted in ascending order (with possible duplicates), regardless of the order the timepoints were specified upon input. */
-    std::list<double> dotimes;
-    /** Lists to contain the dense output of the solution and its derivative */
-    std::list<std::complex<double>> dosol, dodsol;
-    /** Iterator to iterate over the dense output timepoints, for when these
-     * need to be written out to file */
-    std::list<double>::iterator dotit;
-    // Experimental: list to contain continuous representation of the solution
-    std::list<Eigen::Matrix<std::complex<double>,7,1>> sol_vdm;
+  void solve();
 
+  /** Object to call RK steps */
+  RKSolver rksolver;
+
+  /** Successful, total attempted, and successful WKB steps the solver took,
+   * respectively  */
+  int ssteps, totsteps, wkbsteps;
+  /** Lists to contain the solution and its derivative evaluated at internal
+   * points taken by the solver (i.e. not dense output) after a run */
+  std::list<std::complex<double>> sol, dsol;
+  /** List to contain the timepoints at which the solution and derivative are
+   * internally evaluated by the solver */
+  std::list<double> times;
+  /** List to contain the "type" of each step (RK/WKB) taken internally by the
+   * solver after a run */
+  std::list<bool> wkbs;
+  /** Lists to contain the timepoints at which dense output was evaluated. This
+   * list will always be sorted in ascending order (with possible duplicates),
+   * regardless of the order the timepoints were specified upon input. */
+  std::list<double> dotimes;
+  /** Lists to contain the dense output of the solution and its derivative */
+  std::list<std::complex<double>> dosol, dodsol;
+  /** Iterator to iterate over the dense output timepoints, for when these
+   * need to be written out to file */
+  std::list<double>::iterator dotit;
+  // Experimental: list to contain continuous representation of the solution
+  std::list<Eigen::Matrix<std::complex<double>, 7, 1>> sol_vdm;
 };
 
 /** Constructor for when dense output was not requested. Sets up solution of the
@@ -77,86 +77,87 @@ class Solution
  *
  * @param[in] de_sys de_system object carrying information about the ODE being
  * solved
- * @param[in] x0, dx0 initial conditions for the ODE, \f$ x(t) \f$, \f$ \frac{dx}{dt} \f$ evaluated at 
- * the start of the integration range
+ * @param[in] x0, dx0 initial conditions for the ODE, \f$ x(t) \f$, \f$
+ * \frac{dx}{dt} \f$ evaluated at the start of the integration range
  * @param[in] t_i start of integration range
  * @param[in] t_f end of integration range
  * @param[in] o order of WKB approximation to be used
  * @param[in] r_tol (local) relative tolerance
- * @param[in] a_tol (local) absolute tolerance 
+ * @param[in] a_tol (local) absolute tolerance
  * @param[in] h_0 initial stepsize to use
  * @param[in] full_output file name to write results to
- *  
- */ 
+ *
+ */
 Solution::Solution(de_system &de_sys, std::complex<double> x0,
-std::complex<double> dx0, double t_i, double t_f, int o, double r_tol, double
-a_tol, double h_0, const char* full_output){
-    
-    // Make underlying equation system accessible
-    de_sys_ = &de_sys;
+                   std::complex<double> dx0, double t_i, double t_f, int o,
+                   double r_tol, double a_tol, double h_0,
+                   const char *full_output) {
 
-    // Set parameters for solver
-    x = x0;
-    dx = dx0;
-    t = t_i;
-    tf = t_f;
-    order = o;
-    rtol = r_tol;
-    atol = a_tol;
-    h0 = h_0;
-    fo = full_output;
-    rksolver = RKSolver(*de_sys_);
+  // Make underlying equation system accessible
+  de_sys_ = &de_sys;
 
-    // Determine direction of integration, fend>0 and integration ends when
-    // it crosses zero
-    if((t>=tf) && h0<0){
-        // backwards
-        fend = t-tf;
-        fnext = fend;
-        if(de_sys_->is_interpolated == 1){
-            de_sys_->Winterp.sign_ = 0;
-            de_sys_->Ginterp.sign_ = 0;
-        }
-        else
-            sign = 0;
+  // Set parameters for solver
+  x = x0;
+  dx = dx0;
+  t = t_i;
+  tf = t_f;
+  order = o;
+  rtol = r_tol;
+  atol = a_tol;
+  h0 = h_0;
+  fo = full_output;
+  rksolver = RKSolver(*de_sys_);
 
-    }
-    else if((t<=tf) && h0>0){
-        // forward
-        fend = tf-t;
-        fnext = fend;
-        if(de_sys_->is_interpolated == 1){
-            de_sys_->Winterp.sign_ = 1;
-            de_sys_->Ginterp.sign_ = 1;
-        }
-        else
-            sign = 1;
-    }
-    else{
-        throw std::logic_error("Direction of integration in conflict with direction of initial step, terminating. Please check your values for ti, tf, and h.");
-        return;
-    }
+  // Determine direction of integration, fend>0 and integration ends when
+  // it crosses zero
+  if ((t >= tf) && h0 < 0) {
+    // backwards
+    fend = t - tf;
+    fnext = fend;
+    if (de_sys_->is_interpolated == 1) {
+      de_sys_->Winterp.sign_ = 0;
+      de_sys_->Ginterp.sign_ = 0;
+    } else
+      sign = 0;
 
-    // No dense output desired if this constructor was called, so only output
-    // answer at t_i and t_f
-    dotimes.push_back(t_i);
-    dotimes.push_back(t_f);
-    dosol.push_back(x0);
-    dodsol.push_back(dx0);
-    dotit = dotimes.end();
+  } else if ((t <= tf) && h0 > 0) {
+    // forward
+    fend = tf - t;
+    fnext = fend;
+    if (de_sys_->is_interpolated == 1) {
+      de_sys_->Winterp.sign_ = 1;
+      de_sys_->Ginterp.sign_ = 1;
+    } else
+      sign = 1;
+  } else {
+    throw std::logic_error(
+        "Direction of integration in conflict with direction of initial step, "
+        "terminating. Please check your values for ti, tf, and h.");
+    return;
+  }
 
-    
-    switch(order){
-        case 1: wkbsolver1 = WKBSolver1(*de_sys_, order);
-                wkbsolver = &wkbsolver1;
-                break;
-        case 2: wkbsolver2 = WKBSolver2(*de_sys_, order);
-                wkbsolver = &wkbsolver2;
-                break;
-        case 3: wkbsolver3 = WKBSolver3(*de_sys_, order);
-                wkbsolver = &wkbsolver3;
-                break;
-    };
+  // No dense output desired if this constructor was called, so only output
+  // answer at t_i and t_f
+  dotimes.push_back(t_i);
+  dotimes.push_back(t_f);
+  dosol.push_back(x0);
+  dodsol.push_back(dx0);
+  dotit = dotimes.end();
+
+  switch (order) {
+  case 1:
+    wkbsolver1 = WKBSolver1(*de_sys_, order);
+    wkbsolver = &wkbsolver1;
+    break;
+  case 2:
+    wkbsolver2 = WKBSolver2(*de_sys_, order);
+    wkbsolver = &wkbsolver2;
+    break;
+  case 3:
+    wkbsolver3 = WKBSolver3(*de_sys_, order);
+    wkbsolver = &wkbsolver3;
+    break;
+  };
 };
 
 /** Constructor for when dense output was requested. Sets up solution of the
@@ -164,98 +165,102 @@ a_tol, double h_0, const char* full_output){
  *
  * @param[in] de_sys de_system object carrying information about the ODE being
  * solved
- * @param[in] x0, dx0 initial conditions for the ODE, \f$ x(t) \f$, \f$ \frac{dx}{dt} \f$ evaluated at 
- * the start of the integration range
+ * @param[in] x0, dx0 initial conditions for the ODE, \f$ x(t) \f$, \f$
+ * \frac{dx}{dt} \f$ evaluated at the start of the integration range
  * @param[in] t_i start of integration range
  * @param[in] t_f end of integration range
- * @param[in] do_times timepoints at which dense output is to be produced. Doesn't need to be sorted, and duplicated are allowed.
+ * @param[in] do_times timepoints at which dense output is to be produced.
+ * Doesn't need to be sorted, and duplicated are allowed.
  * @param[in] o order of WKB approximation to be used
  * @param[in] r_tol (local) relative tolerance
- * @param[in] a_tol (local) absolute tolerance 
+ * @param[in] a_tol (local) absolute tolerance
  * @param[in] h_0 initial stepsize to use
  * @param[in] full_output file name to write results to
- *  
- */ 
-template<typename X> Solution::Solution(de_system &de_sys, std::complex<double> x0,
-std::complex<double> dx0, double t_i, double t_f, const X &do_times, int o, double r_tol, double
-a_tol, double h_0, const char* full_output){
+ *
+ */
+template <typename X>
+Solution::Solution(de_system &de_sys, std::complex<double> x0,
+                   std::complex<double> dx0, double t_i, double t_f,
+                   const X &do_times, int o, double r_tol, double a_tol,
+                   double h_0, const char *full_output) {
 
-    // Make underlying equation system accessible
-    de_sys_ = &de_sys;
-    // Set parameters for solver
-    x = x0;
-    dx = dx0;
-    t = t_i;
-    tf = t_f;
-    order = o;
-    rtol = r_tol;
-    atol = a_tol;
-    h0 = h_0;
-    fo = full_output;
-    rksolver = RKSolver(*de_sys_);
+  // Make underlying equation system accessible
+  de_sys_ = &de_sys;
+  // Set parameters for solver
+  x = x0;
+  dx = dx0;
+  t = t_i;
+  tf = t_f;
+  order = o;
+  rtol = r_tol;
+  atol = a_tol;
+  h0 = h_0;
+  fo = full_output;
+  rksolver = RKSolver(*de_sys_);
 
-    // Determine direction of integration, fend>0 and integration ends when
-    // it crosses zero
-    if((t>=tf) && h0<0){
-        // backwards
-        fend = t-tf;
-        fnext = fend;
-        if(de_sys_->is_interpolated == 1){
-            de_sys_->Winterp.sign_ = 0;
-            de_sys_->Ginterp.sign_ = 0;
-        }
-        else
-            sign = 0;
-    }
-    else if((t<=tf) && h0>0){
-        // forward
-        fend = tf-t;
-        fnext = fend;
-        if(de_sys_->is_interpolated == 1){
-            de_sys_->Winterp.sign_ = 1;
-            de_sys_->Ginterp.sign_ = 1;
-        }
-        else
-            sign = 1;
-    }
-    else{
-        throw std::logic_error("Direction of integration in conflict with direction of initial step, terminating. Please check your values for ti, tf, and h.");
-        return;
-    }
+  // Determine direction of integration, fend>0 and integration ends when
+  // it crosses zero
+  if ((t >= tf) && h0 < 0) {
+    // backwards
+    fend = t - tf;
+    fnext = fend;
+    if (de_sys_->is_interpolated == 1) {
+      de_sys_->Winterp.sign_ = 0;
+      de_sys_->Ginterp.sign_ = 0;
+    } else
+      sign = 0;
+  } else if ((t <= tf) && h0 > 0) {
+    // forward
+    fend = tf - t;
+    fnext = fend;
+    if (de_sys_->is_interpolated == 1) {
+      de_sys_->Winterp.sign_ = 1;
+      de_sys_->Ginterp.sign_ = 1;
+    } else
+      sign = 1;
+  } else {
+    throw std::logic_error(
+        "Direction of integration in conflict with direction of initial step, "
+        "terminating. Please check your values for ti, tf, and h.");
+    return;
+  }
 
-    // Dense output preprocessing: sort and reverse if necessary
-    int dosize = do_times.size();
-    dotimes.resize(dosize);
-    dosol.resize(dosize);
-    dodsol.resize(dosize);
+  // Dense output preprocessing: sort and reverse if necessary
+  int dosize = do_times.size();
+  dotimes.resize(dosize);
+  dosol.resize(dosize);
+  dodsol.resize(dosize);
 
-    // Copy dense output points to list
-    auto doit = do_times.begin();
-    for(auto it=dotimes.begin(); it!=dotimes.end(); it++){
-        *it = *doit;
-        doit++;
-    }
-    // Sort to ensure ascending order
-    dotimes.sort();
+  // Copy dense output points to list
+  auto doit = do_times.begin();
+  for (auto it = dotimes.begin(); it != dotimes.end(); it++) {
+    *it = *doit;
+    doit++;
+  }
+  // Sort to ensure ascending order
+  dotimes.sort();
 
-    // Reverse if necessary
-    if((de_sys_->is_interpolated == 1 && de_sys_->Winterp.sign_ == 0) || (de_sys_->is_interpolated == 0 && sign == 0)){
-        dotimes.reverse();
-    }
+  // Reverse if necessary
+  if ((de_sys_->is_interpolated == 1 && de_sys_->Winterp.sign_ == 0) ||
+      (de_sys_->is_interpolated == 0 && sign == 0)) {
+    dotimes.reverse();
+  }
 
-    dotit = dotimes.begin();
-    switch(order){
-        case 1: wkbsolver1 = WKBSolver1(*de_sys_, order);
-                wkbsolver = &wkbsolver1;
-                break;
-        case 2: wkbsolver2 = WKBSolver2(*de_sys_, order);
-                wkbsolver = &wkbsolver2;
-                break;
-        case 3: wkbsolver3 = WKBSolver3(*de_sys_, order);
-                wkbsolver = &wkbsolver3;
-                break;
-    };
-
+  dotit = dotimes.begin();
+  switch (order) {
+  case 1:
+    wkbsolver1 = WKBSolver1(*de_sys_, order);
+    wkbsolver = &wkbsolver1;
+    break;
+  case 2:
+    wkbsolver2 = WKBSolver2(*de_sys_, order);
+    wkbsolver = &wkbsolver2;
+    break;
+  case 3:
+    wkbsolver3 = WKBSolver3(*de_sys_, order);
+    wkbsolver = &wkbsolver3;
+    break;
+  };
 };
 
 /** \brief Function to solve the ODE \f$ \ddot{x} + 2\gamma(t)\dot{x} +
@@ -263,277 +268,282 @@ a_tol, double h_0, const char* full_output){
  *
  * While solving the ODE, this function will populate the \a Solution object
  * with the following results:
- * 
+ *
  */
-void Solution::solve(){ 
-    
-    int nrk, nwkb1, nwkb2;
-    // Settings for MS
-    nrk = 5;
-    nwkb1 = 2;
-    nwkb2 = 4;
-    Eigen::Matrix<std::complex<double>,2,2> rkstep;
-    Eigen::Matrix<std::complex<double>,3,2> wkbstep;
-    Eigen::Matrix<std::complex<double>,1,2> rkx, wkbx;
-    Eigen::Matrix<std::complex<double>,1,2> rkerr, wkberr, truncerr;
-    Eigen::Matrix<double,1,2> errmeasure_rk; 
-    Eigen::Matrix<double,1,4> errmeasure_wkb;
-    double tnext, hnext, h, hrk, hwkb;
-    double wkbdelta, rkdelta;
-    std::complex<double> xnext, dxnext;
-    bool wkb = false;
-    Eigen::Index maxindex_wkb, maxindex_rk;
-    h = h0;
-    tnext = t+h;
-    // Initialise stats
-    sol.push_back(x);
-    dsol.push_back(dx);
-    times.push_back(t);
-    wkbs.push_back(false);
-    ssteps = 0;
-    totsteps = 0;
-    wkbsteps = 0;
-    // Dense output
-    std::list<double> inner_dotimes;
-    std::list<std::complex<double>> inner_dosols, inner_dodsols;
-    auto it_dosol = dosol.begin();
-    auto it_dodsol = dodsol.begin();
-    Eigen::Matrix<std::complex<double>,1,2> y_dense_rk;
-    std::complex<double> x_dense_rk, dx_dense_rk;
-    // Experimental continuous solution, vandermonde representation
-    Eigen::Matrix<std::complex<double>,7,1> xvdm;
+void Solution::solve() {
 
-    while(fend > 0){
-        // Check if we are reaching the end of integration
-        if(fnext < 0){
-            h = tf - t;
-            tnext = tf;
+  int nrk, nwkb1, nwkb2;
+  // Settings for MS
+  nrk = 5;
+  nwkb1 = 2;
+  nwkb2 = 4;
+  Eigen::Matrix<std::complex<double>, 2, 2> rkstep;
+  Eigen::Matrix<std::complex<double>, 3, 2> wkbstep;
+  Eigen::Matrix<std::complex<double>, 1, 2> rkx, wkbx;
+  Eigen::Matrix<std::complex<double>, 1, 2> rkerr, wkberr, truncerr;
+  Eigen::Matrix<double, 1, 2> errmeasure_rk;
+  Eigen::Matrix<double, 1, 4> errmeasure_wkb;
+  double tnext, hnext, h, hrk, hwkb;
+  double wkbdelta, rkdelta;
+  std::complex<double> xnext, dxnext;
+  bool wkb = false;
+  Eigen::Index maxindex_wkb, maxindex_rk;
+  h = h0;
+  tnext = t + h;
+  // Initialise stats
+  sol.push_back(x);
+  dsol.push_back(dx);
+  times.push_back(t);
+  wkbs.push_back(false);
+  ssteps = 0;
+  totsteps = 0;
+  wkbsteps = 0;
+  // Dense output
+  std::list<double> inner_dotimes;
+  std::list<std::complex<double>> inner_dosols, inner_dodsols;
+  auto it_dosol = dosol.begin();
+  auto it_dodsol = dodsol.begin();
+  Eigen::Matrix<std::complex<double>, 1, 2> y_dense_rk;
+  std::complex<double> x_dense_rk, dx_dense_rk;
+  // Experimental continuous solution, vandermonde representation
+  Eigen::Matrix<std::complex<double>, 7, 1> xvdm;
+
+  while (fend > 0) {
+    // Check if we are reaching the end of integration
+    if (fnext < 0) {
+      h = tf - t;
+      tnext = tf;
+    }
+
+    // Keep updating stepsize until step is accepted
+    while (true) {
+      // RK step
+      rkstep = rksolver.step(x, dx, t, h);
+      rkx << rkstep(0, 0), rkstep(0, 1);
+      rkerr << rkstep(1, 0), rkstep(1, 1);
+      // WKB step
+      wkbstep = wkbsolver->step(x, dx, t, h, rksolver.ws, rksolver.gs,
+                                rksolver.ws5, rksolver.gs5);
+      wkbx = wkbstep.row(0);
+      wkberr = wkbstep.row(2);
+      truncerr = wkbstep.row(1);
+      // Safety feature for when all wkb steps are 0 (truncer=0), but not
+      // necessarily in good WKB regime:
+      truncerr(0) = std::max(1e-10, abs(truncerr(0)));
+      truncerr(1) = std::max(1e-10, abs(truncerr(1)));
+      // dominant error calculation
+      // Error scale measures
+      errmeasure_rk << std::abs(rkerr(0)) / (std::abs(rkx(0)) * rtol + atol),
+          std::abs(rkerr(1)) / (std::abs(rkx(1)) * rtol + atol);
+      errmeasure_wkb << std::abs(truncerr(0)) /
+                            (std::abs(wkbx(0)) * rtol + atol),
+          std::abs(truncerr(1)) / (std::abs(wkbx(1)) * rtol + atol),
+          std::abs(wkberr(0)) / (std::abs(wkbx(0)) * rtol + atol),
+          std::abs(wkberr(1)) / (std::abs(wkbx(1)) * rtol + atol);
+      rkdelta = std::max(1e-10, errmeasure_rk.maxCoeff(&maxindex_rk));
+      if (std::isnan(errmeasure_wkb.maxCoeff()) == false &&
+          std::isinf(std::real(wkbx(0))) == false &&
+          std::isinf(std::imag(wkbx(0))) == false &&
+          std::isinf(std::real(wkbx(1))) == false &&
+          std::isinf(std::imag(wkbx(1))) == false &&
+          std::isnan(std::real(wkbx(0))) == false &&
+          std::isnan(std::imag(wkbx(0))) == false &&
+          std::isnan(std::real(wkbx(1))) == false &&
+          std::isnan(std::imag(wkbx(1))) == false) {
+        wkbdelta = std::max(1e-10, errmeasure_wkb.maxCoeff(&maxindex_wkb));
+      } else {
+        wkbdelta = std::numeric_limits<double>::infinity();
+      }
+
+      // predict next stepsize
+      hrk = h * std::pow((1.0 / rkdelta), 1.0 / nrk);
+      if (maxindex_wkb <= 1)
+        hwkb = h * std::pow(1.0 / wkbdelta, 1.0 / nwkb1);
+      else
+        hwkb = h * std::pow(1.0 / wkbdelta, 1.0 / nwkb2);
+      // choose step with larger predicted stepsize
+      if (std::abs(hwkb) >= std::abs(hrk)) {
+        wkb = true;
+      } else {
+        wkb = false;
+      }
+      if (wkb) {
+        xnext = wkbx(0);
+        dxnext = wkbx(1);
+        // if wkb step chosen, ignore truncation error in
+        // stepsize-increase
+        wkbdelta = std::max(1e-10, errmeasure_wkb.tail(2).maxCoeff());
+        hnext = h * std::pow(1.0 / wkbdelta, 1.0 / nwkb2);
+      } else {
+        xnext = rkx(0);
+        dxnext = rkx(1);
+        hnext = hrk;
+      }
+      totsteps += 1;
+      // Checking for too many steps and low acceptance ratio:
+      if (totsteps % 5000 == 0) {
+        std::cerr << "Warning: the solver took " << totsteps
+                  << " steps, and may take a while to converge." << std::endl;
+        if (ssteps / totsteps < 0.05) {
+          std::cerr << "Warning: the step acceptance ratio is below 5%, the "
+                       "solver may take a while to converge."
+                    << std::endl;
+        }
+      }
+
+      // check if chosen step was successful
+      if (std::abs(hnext) >= std::abs(h)) {
+        //                std::cout << "All dense output points: " << std::endl;
+        if (dotit != dotimes.end()) {
+          //                    std::cout << *dotit << std::endl;
+          while ((*dotit - t >= 0 && tnext - *dotit >= 0) ||
+                 (*dotit - t <= 0 && tnext - *dotit <= 0)) {
+            inner_dotimes.push_back(*dotit);
+            dotit++;
+          }
+          if (inner_dotimes.size() > 0) {
+            inner_dosols.resize(inner_dotimes.size());
+            inner_dodsols.resize(inner_dotimes.size());
+            if (wkb) {
+              // Dense output after successful WKB step
+              //                            std::cout << "Attempting " <<
+              //                            inner_dosols.size() << " dense
+              //                            output points after successful WKB
+              //                            step from " << t << " to " << t+h <<
+              //                            std::endl;
+
+              wkbsolver->dense_step(t, inner_dotimes, inner_dosols,
+                                    inner_dodsols);
+            } else {
+              // Dense output after successful RK step
+              for (auto it = inner_dotimes.begin(); it != inner_dotimes.end();
+                   it++)
+                rksolver.dense_step(t, h, x, dx, inner_dotimes, inner_dosols,
+                                    inner_dodsols);
+            }
+          }
+        }
+        auto inner_it = inner_dosols.begin();
+        auto inner_dit = inner_dodsols.begin();
+        while (inner_it != inner_dosols.end() && it_dosol != dosol.end() &&
+               inner_dit != inner_dodsols.end() && it_dodsol != dodsol.end()) {
+          *it_dosol = *inner_it;
+          *it_dodsol = *inner_dit;
+          it_dodsol++;
+          it_dosol++;
+          inner_it++;
+          inner_dit++;
+        }
+        inner_dotimes.resize(0);
+        inner_dosols.resize(0);
+        inner_dodsols.resize(0);
+
+        // record type of step
+        if (wkb) {
+          wkbsteps += 1;
+          wkbs.push_back(true);
+          xvdm = wkbsolver->x_vdm;
+        } else {
+          wkbs.push_back(false);
+          xvdm = rksolver.x_vdm;
+        }
+        sol.push_back(xnext);
+        dsol.push_back(dxnext);
+        sol_vdm.push_back(xvdm);
+        times.push_back(tnext);
+        tnext += hnext;
+        x = xnext;
+        dx = dxnext;
+        t += h;
+        h = hnext;
+        if (h > 0) {
+          fend = tf - t;
+          fnext = tf - tnext;
+        } else {
+          fend = t - tf;
+          fnext = tnext - tf;
+        }
+        ssteps += 1;
+        // Update interpolation bounds
+        if (de_sys_->is_interpolated == 1) {
+          de_sys_->Winterp.update_interp_bounds();
+          de_sys_->Ginterp.update_interp_bounds();
         }
 
-        // Keep updating stepsize until step is accepted
-        while(true){
-            // RK step
-            rkstep = rksolver.step(x, dx, t, h);
-            rkx << rkstep(0,0), rkstep(0,1);
-            rkerr << rkstep(1,0), rkstep(1,1);
-            // WKB step
-            wkbstep = wkbsolver->step(x, dx, t, h, rksolver.ws, rksolver.gs, rksolver.ws5, rksolver.gs5);
-            wkbx = wkbstep.row(0);
-            wkberr = wkbstep.row(2);
-            truncerr = wkbstep.row(1);
-            // Safety feature for when all wkb steps are 0 (truncer=0), but not
-            // necessarily in good WKB regime:
-            truncerr(0) = std::max(1e-10,abs(truncerr(0)));
-            truncerr(1) = std::max(1e-10,abs(truncerr(1)));
-            // dominant error calculation
-            // Error scale measures
-            errmeasure_rk << std::abs(rkerr(0))/(std::abs(rkx(0))*rtol+atol), std::abs(rkerr(1))/(std::abs(rkx(1))*rtol+atol);
-            errmeasure_wkb << std::abs(truncerr(0))/(std::abs(wkbx(0))*rtol+atol),
-            std::abs(truncerr(1))/(std::abs(wkbx(1))*rtol+atol),
-            std::abs(wkberr(0))/(std::abs(wkbx(0))*rtol+atol),
-            std::abs(wkberr(1))/(std::abs(wkbx(1))*rtol+atol);
-            rkdelta = std::max(1e-10, errmeasure_rk.maxCoeff(&maxindex_rk)); 
-            if(std::isnan(errmeasure_wkb.maxCoeff())==false &&
-               std::isinf(std::real(wkbx(0)))==false &&
-               std::isinf(std::imag(wkbx(0)))==false &&
-               std::isinf(std::real(wkbx(1)))==false &&
-               std::isinf(std::imag(wkbx(1)))==false &&
-               std::isnan(std::real(wkbx(0)))==false &&
-               std::isnan(std::imag(wkbx(0)))==false &&
-               std::isnan(std::real(wkbx(1)))==false &&
-               std::isnan(std::imag(wkbx(1)))==false){
-                wkbdelta = std::max(1e-10, errmeasure_wkb.maxCoeff(&maxindex_wkb));
-            }
-            else{
-                wkbdelta = std::numeric_limits<double>::infinity();
-            }
-
-            // predict next stepsize 
-            hrk = h*std::pow((1.0/rkdelta),1.0/nrk);
-            if(maxindex_wkb<=1)
-                hwkb = h*std::pow(1.0/wkbdelta,1.0/nwkb1);
+        break;
+      } else {
+        if (wkb) {
+          if (maxindex_wkb <= 1) {
+            if (nwkb1 > 1)
+              hnext = h * std::pow(1.0 / wkbdelta, 1.0 / (nwkb1 - 1));
             else
-                hwkb = h*std::pow(1.0/wkbdelta,1.0/nwkb2);
-            // choose step with larger predicted stepsize
-            if(std::abs(hwkb) >= std::abs(hrk)){
-                wkb = true;
-            }
-            else{
-                wkb = false;
-            }
-            if(wkb){
-                xnext = wkbx(0);
-                dxnext = wkbx(1);
-                // if wkb step chosen, ignore truncation error in
-                // stepsize-increase
-                wkbdelta = std::max(1e-10, errmeasure_wkb.tail(2).maxCoeff());
-                hnext = h*std::pow(1.0/wkbdelta,1.0/nwkb2);
-            }
-            else{
-                xnext = rkx(0);
-                dxnext = rkx(1);
-                hnext = hrk;
-            }
-            totsteps += 1;
-            // Checking for too many steps and low acceptance ratio:
-            if(totsteps % 5000 == 0){
-                std::cerr << "Warning: the solver took " << totsteps << " steps, and may take a while to converge." << std::endl; 
-                if(ssteps/totsteps < 0.05){
-                    std::cerr << "Warning: the step acceptance ratio is below 5%, the solver may take a while to converge." << std::endl;
-                }
-            }
-
-            // check if chosen step was successful
-            if(std::abs(hnext)>=std::abs(h)){
-//                std::cout << "All dense output points: " << std::endl;
-                if(dotit!=dotimes.end()){
-//                    std::cout << *dotit << std::endl;
-                    while((*dotit-t>=0 && tnext-*dotit>=0) || (*dotit-t<=0 && tnext-*dotit<=0)){
-                        inner_dotimes.push_back(*dotit);
-                        dotit++;
-                    }
-                    if(inner_dotimes.size() > 0){
-                        inner_dosols.resize(inner_dotimes.size());
-                        inner_dodsols.resize(inner_dotimes.size());
-                        if(wkb){
-                            // Dense output after successful WKB step
-//                            std::cout << "Attempting " << inner_dosols.size() << " dense output points after successful WKB step from " << t << " to " << t+h << std::endl;
-
-                            wkbsolver->dense_step(t,inner_dotimes,inner_dosols,inner_dodsols);
-                        }
-                        else{
-                            // Dense output after successful RK step
-                            for(auto it=inner_dotimes.begin(); it!=inner_dotimes.end(); it++)
-                                rksolver.dense_step(t,h,x,dx,inner_dotimes,inner_dosols,inner_dodsols);
-                        }
-                    }
-                }
-                auto inner_it=inner_dosols.begin();
-                auto inner_dit=inner_dodsols.begin();
-                while(inner_it!=inner_dosols.end() && it_dosol!=dosol.end() && inner_dit!=inner_dodsols.end() && it_dodsol!=dodsol.end()){
-                    *it_dosol = *inner_it;
-                    *it_dodsol = *inner_dit;
-                    it_dodsol++;
-                    it_dosol++;
-                    inner_it++;
-                    inner_dit++;
-                }
-                inner_dotimes.resize(0);
-                inner_dosols.resize(0);
-                inner_dodsols.resize(0);
-               
-                // record type of step
-                if(wkb){
-                    wkbsteps +=1;
-                    wkbs.push_back(true);
-                    xvdm = wkbsolver->x_vdm;
-                }
-                else{
-                    wkbs.push_back(false);
-                    xvdm = rksolver.x_vdm; 
-                }
-                sol.push_back(xnext);
-                dsol.push_back(dxnext);
-                sol_vdm.push_back(xvdm);
-                times.push_back(tnext);
-                tnext += hnext;
-                x = xnext;
-                dx = dxnext;
-                t += h;
-                h = hnext;
-                if(h>0){
-                    fend=tf-t;
-                    fnext=tf-tnext;
-                }
-                else{
-                    fend=t-tf;
-                    fnext=tnext-tf;
-                }
-                ssteps +=1;
-                // Update interpolation bounds
-                if(de_sys_->is_interpolated == 1){
-                    de_sys_->Winterp.update_interp_bounds();
-                    de_sys_->Ginterp.update_interp_bounds();
-                }
-
-                break;
-            }
-            else{
-                if(wkb){
-                    if(maxindex_wkb<=1){
-                        if(nwkb1 > 1)
-                            hnext = h*std::pow(1.0/wkbdelta,1.0/(nwkb1-1));
-                        else
-                            hnext = 0.95*h*1.0/wkbdelta;
-                    }
-                    else
-                        hnext = h*std::pow(1.0/wkbdelta,1.0/(nwkb2-1));
-                }
-                else
-                    hnext = h*std::pow(1.0/rkdelta,1.0/(nrk-1));
-                h = hnext;
-                tnext = t + hnext;
-                if(h>0){
-                    fnext=tf-tnext;
-                }
-                else{
-                    fnext=tnext-tf;
-                }
-            }
+              hnext = 0.95 * h * 1.0 / wkbdelta;
+          } else
+            hnext = h * std::pow(1.0 / wkbdelta, 1.0 / (nwkb2 - 1));
+        } else
+          hnext = h * std::pow(1.0 / rkdelta, 1.0 / (nrk - 1));
+        h = hnext;
+        tnext = t + hnext;
+        if (h > 0) {
+          fnext = tf - tnext;
+        } else {
+          fnext = tnext - tf;
         }
+      }
+    }
+  }
+
+  // If integrating backwards, reverse dense output (because it will have been
+  // reversed at the start)
+  if (de_sys_->is_interpolated == 1) {
+    if (de_sys_->Winterp.sign_ == 0) {
+      dotimes.reverse();
+      dosol.reverse();
+      dodsol.reverse();
+    }
+  } else {
+    if (sign == 0) {
+      dotimes.reverse();
+      dosol.reverse();
+      dodsol.reverse();
+    }
+  }
+
+  // Write output to file if prompted
+  if (!(*fo == 0)) {
+    std::string output(fo);
+    std::ofstream f;
+    f.open(output);
+    f << "# Summary:\n# total steps taken: " + std::to_string(totsteps) +
+             "\n# of which successful: " + std::to_string(ssteps) +
+             "\n# of which" + +" wkb: " + std::to_string(wkbsteps) +
+             "\n# time, sol, dsol, wkb? (type)\n";
+    auto it_t = times.begin();
+    auto it_w = wkbs.begin();
+    auto it_x = sol.begin();
+    auto it_dx = dsol.begin();
+    for (int i = 0; i <= ssteps; i++) {
+      f << std::setprecision(15) << *it_t << ";" << std::setprecision(15)
+        << *it_x << ";" << std::setprecision(15) << *it_dx << ";" << *it_w
+        << "\n";
+      ++it_t;
+      ++it_x;
+      ++it_dx;
+      ++it_w;
+    }
+    // print all dense output to file
+    int dosize = dosol.size();
+    auto it_dosol = dosol.begin();
+    auto it_dotimes = dotimes.begin();
+    auto it_dodsol = dodsol.begin();
+    for (int i = 0; i < dosize; i++) {
+      f << std::setprecision(20) << *it_dotimes << ";" << std::setprecision(20)
+        << *it_dosol << ";" << *it_dodsol << ";\n";
+      ++it_dosol;
+      ++it_dodsol;
+      ++it_dotimes;
     }
 
-    // If integrating backwards, reverse dense output (because it will have been
-    // reversed at the start)
-    if(de_sys_->is_interpolated == 1){
-        if(de_sys_->Winterp.sign_ == 0){
-            dotimes.reverse();
-            dosol.reverse();
-            dodsol.reverse();
-        }
-    }
-    else{
-        if(sign == 0){
-            dotimes.reverse();
-            dosol.reverse();
-            dodsol.reverse();
-        }
-    }
-
-    // Write output to file if prompted
-    if(!(*fo==0)){
-        std::string output(fo);
-        std::ofstream f;
-        f.open(output);
-        f << "# Summary:\n# total steps taken: " + std::to_string(totsteps) +
-        "\n# of which successful: " + std::to_string(ssteps) + "\n# of which"+
-        +" wkb: " + std::to_string(wkbsteps) + "\n# time, sol, dsol, wkb? (type)\n";
-        auto it_t = times.begin();
-        auto it_w = wkbs.begin();
-        auto it_x = sol.begin();
-        auto it_dx = dsol.begin();
-        for(int i=0; i<=ssteps; i++){
-            f << std::setprecision(15) << *it_t << ";" <<
-            std::setprecision(15) << *it_x << ";" << std::setprecision(15) <<
-            *it_dx << ";" << *it_w << "\n"; 
-            ++it_t;
-            ++it_x;
-            ++it_dx;
-            ++it_w;
-        }
-        // print all dense output to file
-        int dosize = dosol.size();
-        auto it_dosol = dosol.begin();
-        auto it_dotimes = dotimes.begin();
-        auto it_dodsol = dodsol.begin();
-        for(int i=0; i<dosize; i++){
-            f << std::setprecision(20) << *it_dotimes << ";" << std::setprecision(20) << *it_dosol << ";" << *it_dodsol << ";\n";
-            ++it_dosol;
-            ++it_dodsol;
-            ++it_dotimes;
-        }
-
-        f.close();
-    }
-   
+    f.close();
+  }
 };

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#include "interpolator.hpp"
-#include "rksolver.hpp"
-#include "system.hpp"
-#include "wkbsolver.hpp"
+#include <interpolator.hpp>
+#include <rksolver.hpp>
+#include <system.hpp>
+#include <wkbsolver.hpp>
 #include <Eigen/Dense>
 #include <fstream>
 #include <iomanip>

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -2,106 +2,104 @@
 #include "interpolator.hpp"
 
 /** */
-class de_system
-    {
-    private:
-        int even_;
+class de_system {
+private:
+  int even_;
 
-    public:
-        template<typename X, typename Y, typename Z, typename X_it>de_system(X
-        &ts, Y &ws, Z &gs, X_it x_it, int size, bool isglogw=false, bool
-        islogg=false, int even=0, int check_grid=0);
-        de_system(std::complex<double> (*)(double, void*), std::complex<double> (*)(double, void*), void*);
-        de_system(std::complex<double> (*)(double), std::complex<double> (*)(double));
-        de_system();
-        std::function<std::complex<double>(double)> w;
-        std::function<std::complex<double>(double)> g;
-        LinearInterpolator<> Winterp;
-        LinearInterpolator<> Ginterp; 
-        bool islogg_, islogw_;
-        bool grid_fine_enough = 1;
-        bool is_interpolated;
+public:
+  template <typename X, typename Y, typename Z, typename X_it>
+  de_system(X &ts, Y &ws, Z &gs, X_it x_it, int size, bool isglogw = false,
+            bool islogg = false, int even = 0, int check_grid = 0);
+  de_system(std::complex<double> (*)(double, void *),
+            std::complex<double> (*)(double, void *), void *);
+  de_system(std::complex<double> (*)(double), std::complex<double> (*)(double));
+  de_system();
+  std::function<std::complex<double>(double)> w;
+  std::function<std::complex<double>(double)> g;
+  LinearInterpolator<> Winterp;
+  LinearInterpolator<> Ginterp;
+  bool islogg_, islogw_;
+  bool grid_fine_enough = 1;
+  bool is_interpolated;
 };
 
 /** Default contructor */
-de_system::de_system(){
-}
+de_system::de_system() {}
 
 /** Constructor for the case of the user having defined the frequency and
  * damping terms as sequences
  */
-template<typename X, typename Y, typename Z, typename X_it>
-de_system::de_system(X &ts, Y &ws, Z &gs, X_it x_it, int size, bool islogw, bool
-islogg, int even, int check_grid){
-    
-    is_interpolated = 1; 
-    even_ = even;
-    islogg_ = islogg;
-    islogw_ = islogw;
+template <typename X, typename Y, typename Z, typename X_it>
+de_system::de_system(X &ts, Y &ws, Z &gs, X_it x_it, int size, bool islogw,
+                     bool islogg, int even, int check_grid) {
 
-    /** Set up interpolation on the supplied frequency and damping arrays */
-    LinearInterpolator<X,Y,X_it> winterp(ts,ws,even_);
-    LinearInterpolator<X,Z,X_it> ginterp(ts,gs,even_);
-    
-    Winterp = winterp;
-    Ginterp = ginterp;
+  is_interpolated = 1;
+  even_ = even;
+  islogg_ = islogg;
+  islogw_ = islogw;
 
-    if(even_==0){
-        Winterp.set_interp_start(x_it);
-        Ginterp.set_interp_start(x_it);
-        Winterp.set_interp_bounds(ts,ts+size-1);
-        Ginterp.set_interp_bounds(ts,ts+size-1);
-    }
-    
-    /** Check if supplied grids are sampled finely enough for the purposes of
-     * linear interpolation
-     */
-    if(check_grid == 1){
-        int w_is_fine = Winterp.check_grid_fineness(size);
-        int g_is_fine = Ginterp.check_grid_fineness(size);
-        if(w_is_fine==1 && g_is_fine==1)
-            grid_fine_enough = 1; 
-        else
-            grid_fine_enough = 0;
-    }
+  /** Set up interpolation on the supplied frequency and damping arrays */
+  LinearInterpolator<X, Y, X_it> winterp(ts, ws, even_);
+  LinearInterpolator<X, Z, X_it> ginterp(ts, gs, even_);
 
-    /** Bind result of interpolation to a function, this will be called by the
-     * routines taking RK and WKB steps
-     */
-    if(islogw)
-        w = std::bind(&LinearInterpolator<X,Y,X_it>::expit, Winterp,
-        std::placeholders::_1);
+  Winterp = winterp;
+  Ginterp = ginterp;
+
+  if (even_ == 0) {
+    Winterp.set_interp_start(x_it);
+    Ginterp.set_interp_start(x_it);
+    Winterp.set_interp_bounds(ts, ts + size - 1);
+    Ginterp.set_interp_bounds(ts, ts + size - 1);
+  }
+
+  /** Check if supplied grids are sampled finely enough for the purposes of
+   * linear interpolation
+   */
+  if (check_grid == 1) {
+    int w_is_fine = Winterp.check_grid_fineness(size);
+    int g_is_fine = Ginterp.check_grid_fineness(size);
+    if (w_is_fine == 1 && g_is_fine == 1)
+      grid_fine_enough = 1;
     else
-        w = std::bind(&LinearInterpolator<X,Y,X_it>::operator(), Winterp,
-        std::placeholders::_1);
-    if(islogg)
-        g = std::bind(&LinearInterpolator<X,Z,X_it>::expit, Ginterp,
-        std::placeholders::_1);
-    else
-        g = std::bind(&LinearInterpolator<X,Z,X_it>::operator(), Ginterp,
-        std::placeholders::_1);
-     
-      
+      grid_fine_enough = 0;
+  }
+
+  /** Bind result of interpolation to a function, this will be called by the
+   * routines taking RK and WKB steps
+   */
+  if (islogw)
+    w = std::bind(&LinearInterpolator<X, Y, X_it>::expit, Winterp,
+                  std::placeholders::_1);
+  else
+    w = std::bind(&LinearInterpolator<X, Y, X_it>::operator(), Winterp,
+                  std::placeholders::_1);
+  if (islogg)
+    g = std::bind(&LinearInterpolator<X, Z, X_it>::expit, Ginterp,
+                  std::placeholders::_1);
+  else
+    g = std::bind(&LinearInterpolator<X, Z, X_it>::operator(), Ginterp,
+                  std::placeholders::_1);
 }
 
 /** Constructor for the case when the frequency and damping terms have been
  * defined as functions
  */
-de_system::de_system(std::complex<double> (*W)(double, void*),
-std::complex<double> (*G)(double, void*), void *p){
-    
-    is_interpolated = 0;
-    w = [W, p](double x){ return W(x, p); };
-    g = [G, p](double x){ return G(x, p); };
+de_system::de_system(std::complex<double> (*W)(double, void *),
+                     std::complex<double> (*G)(double, void *), void *p) {
+
+  is_interpolated = 0;
+  w = [W, p](double x) { return W(x, p); };
+  g = [G, p](double x) { return G(x, p); };
 };
 
 /** Constructor for the case when the frequency and damping terms have been
- * defined as functions (and there are no additional parameters that the function might need)
+ * defined as functions (and there are no additional parameters that the
+ * function might need)
  */
-de_system::de_system(std::complex<double> (*W)(double), std::complex<double> (*G)(double)){
-    
-    is_interpolated = 0;
-    w = W;
-    g = G;
-};
+de_system::de_system(std::complex<double> (*W)(double),
+                     std::complex<double> (*G)(double)) {
 
+  is_interpolated = 0;
+  w = W;
+  g = G;
+};

--- a/include/wkbsolver.hpp
+++ b/include/wkbsolver.hpp
@@ -1,6 +1,9 @@
 #pragma once
-#include "system.hpp"
+#include <system.hpp>
+#include <Eigen/Dense>
+#include <complex>
 #include <iomanip>
+#include <list>
 
 /** Class to carry out WKB steps of varying orders.  */
 class WKBSolver {

--- a/include/wkbsolver.hpp
+++ b/include/wkbsolver.hpp
@@ -1,223 +1,231 @@
 #pragma once
-#include <iomanip>
 #include "system.hpp"
+#include <iomanip>
 
 /** Class to carry out WKB steps of varying orders.  */
-class WKBSolver
-{
-    protected: 
-    // Derivative terms 
-    void d1w1();
-    void d1w2();
-    void d1w3();
-    void d1w4();
-    void d1w5();
-    void d1w6();
-    void d2w1();
-    void d2w2();
-    void d2w3();
-    void d2w4();
-    void d2w5();
-    void d2w6();
-    void d3w1();
-    void d3w2();
-    void d3w3();
-    void d3w4();
-    void d3w5();
-    void d3w6();
-    void d4w1();
-    void d1g1();
-    void d1g2();
-    void d1g3();
-    void d1g4();
-    void d1g5();
-    void d1g6();
-    void d2g1();
-    void d2g2();
-    void d2g3();
-    void d2g4();
-    void d2g5();
-    void d2g6();
-    void d3g1();
-    void d1w2_5();
-    void d1w3_5();
-    void d1w4_5();
-    // WKB series and derivatives (order dependent)
-    virtual void dds();
-    virtual void dsi();
-    virtual void dsf();
-    virtual void s();
-    // WKB solutions and derivatives
-    void fp();
-    void fm();
-    void dfpi();
-    void dfmi();
-    void dfpf();
-    void dfmf();
-    void ddfp();
-    void ddfm();
-    void ap();
-    void am();
-    void bp();
-    void bm();
-    // Gauss-Lobatto integration
-    Eigen::Matrix<std::complex<double>,2,1> integrate(const
-    Eigen::Matrix<std::complex<double>,6,1> &integrand6, const
-    Eigen::Matrix<std::complex<double>,5,1> &integrand5);
+class WKBSolver {
+protected:
+  // Derivative terms
+  void d1w1();
+  void d1w2();
+  void d1w3();
+  void d1w4();
+  void d1w5();
+  void d1w6();
+  void d2w1();
+  void d2w2();
+  void d2w3();
+  void d2w4();
+  void d2w5();
+  void d2w6();
+  void d3w1();
+  void d3w2();
+  void d3w3();
+  void d3w4();
+  void d3w5();
+  void d3w6();
+  void d4w1();
+  void d1g1();
+  void d1g2();
+  void d1g3();
+  void d1g4();
+  void d1g5();
+  void d1g6();
+  void d2g1();
+  void d2g2();
+  void d2g3();
+  void d2g4();
+  void d2g5();
+  void d2g6();
+  void d3g1();
+  void d1w2_5();
+  void d1w3_5();
+  void d1w4_5();
+  // WKB series and derivatives (order dependent)
+  virtual void dds();
+  virtual void dsi();
+  virtual void dsf();
+  virtual void s();
+  // WKB solutions and derivatives
+  void fp();
+  void fm();
+  void dfpi();
+  void dfmi();
+  void dfpf();
+  void dfmf();
+  void ddfp();
+  void ddfm();
+  void ap();
+  void am();
+  void bp();
+  void bm();
+  // Gauss-Lobatto integration
+  Eigen::Matrix<std::complex<double>, 2, 1>
+  integrate(const Eigen::Matrix<std::complex<double>, 6, 1> &integrand6,
+            const Eigen::Matrix<std::complex<double>, 5, 1> &integrand5);
 
-    // Gauss-Lobatto n=6, 5 weights
-    Eigen::Matrix<double,6,1> glws6;
-    Eigen::Matrix<double,5,1> glws5;
-    // weights for derivatives
-    Eigen::Matrix<double,7,1> d4w1_w;
-    Eigen::Matrix<double,6,1> d1w1_w, d1w2_w, d1w3_w, d1w4_w, d1w5_w, d1w6_w,
-    d2w1_w, d2w2_w, d2w3_w, d2w4_w, d2w5_w, d2w6_w, d3w1_w, d3w2_w, d3w3_w, d3w4_w, d3w5_w, d3w6_w, d1g1_w, d1g6_w, d2g1_w, d2g6_w, d3g1_w;
-    Eigen::Matrix<double,5,1> d1w2_5_w, d1w3_5_w, d1w4_5_w;
-    // grid of ws, gs
-    Eigen::Matrix<std::complex<double>,7,1> ws7_;
-    Eigen::Matrix<std::complex<double>,6,1> ws_, gs_;
-    Eigen::Matrix<std::complex<double>,5,1> ws5_, gs5_;
-    // derivatives
-    std::complex<double> d1w1_, d1w2_, d1w3_, d1w4_, d1w5_, d1w6_, d2w1_, d2w2_, d2w3_, d2w4_, d2w5_, d2w6_,
-    d3w1_, d3w2_, d3w3_, d3w4_, d3w5_, d3w6_, d4w1_, d1g1_, d1g2_, d1g3_, d1g4_, d1g5_, d1g6_, d2g1_, d2g2_, d2g3_, d2g4_, d2g5_, d2g6_, d3g1_; 
-    std::complex<double> d1w2_5_, d1w3_5_, d1w4_5_;
-    Eigen::Matrix<std::complex<double>,6,1> dws_, dgs_, d2ws_, d2gs_, d3ws_;
-    Eigen::Matrix<std::complex<double>,5,1> dws5_;
-    // WKB series and their derivatives
-    Eigen::Matrix<std::complex<double>,1,4> dds_, dsi_, dsf_, s_; 
-    // Error in WKB series
-    Eigen::Matrix<std::complex<double>,1,4> s_error;
-    // WKB solutions and their derivatives
-    std::complex<double> fp_, fm_, dfpi_, dfmi_, dfpf_, dfmf_, ddfp_, ddfm_, ap_, am_, bp_, bm_; 
-    // step and stepsize
-    double h;
-    std::complex<double> x, dx, ddx;
-    // order
-    int order_;
-    // error estimate on step
-    std::complex<double> err_fp, err_fm, err_dfp, err_dfm;
-    // dense output
-    std::list<std::complex<double>> doxs, dodxs, dows;
-    Eigen::Matrix<std::complex<double>,1,4> dense_s_, dense_ds_, dense_ds_i;
-    std::complex<double> dense_ap_, dense_am_, dense_bp_, dense_bm_;
-    // experimental dense output + quadrature
-    Eigen::Matrix<double,6,6> integ_vandermonde, interp_vandermonde;
+  // Gauss-Lobatto n=6, 5 weights
+  Eigen::Matrix<double, 6, 1> glws6;
+  Eigen::Matrix<double, 5, 1> glws5;
+  // weights for derivatives
+  Eigen::Matrix<double, 7, 1> d4w1_w;
+  Eigen::Matrix<double, 6, 1> d1w1_w, d1w2_w, d1w3_w, d1w4_w, d1w5_w, d1w6_w,
+      d2w1_w, d2w2_w, d2w3_w, d2w4_w, d2w5_w, d2w6_w, d3w1_w, d3w2_w, d3w3_w,
+      d3w4_w, d3w5_w, d3w6_w, d1g1_w, d1g6_w, d2g1_w, d2g6_w, d3g1_w;
+  Eigen::Matrix<double, 5, 1> d1w2_5_w, d1w3_5_w, d1w4_5_w;
+  // grid of ws, gs
+  Eigen::Matrix<std::complex<double>, 7, 1> ws7_;
+  Eigen::Matrix<std::complex<double>, 6, 1> ws_, gs_;
+  Eigen::Matrix<std::complex<double>, 5, 1> ws5_, gs5_;
+  // derivatives
+  std::complex<double> d1w1_, d1w2_, d1w3_, d1w4_, d1w5_, d1w6_, d2w1_, d2w2_,
+      d2w3_, d2w4_, d2w5_, d2w6_, d3w1_, d3w2_, d3w3_, d3w4_, d3w5_, d3w6_,
+      d4w1_, d1g1_, d1g2_, d1g3_, d1g4_, d1g5_, d1g6_, d2g1_, d2g2_, d2g3_,
+      d2g4_, d2g5_, d2g6_, d3g1_;
+  std::complex<double> d1w2_5_, d1w3_5_, d1w4_5_;
+  Eigen::Matrix<std::complex<double>, 6, 1> dws_, dgs_, d2ws_, d2gs_, d3ws_;
+  Eigen::Matrix<std::complex<double>, 5, 1> dws5_;
+  // WKB series and their derivatives
+  Eigen::Matrix<std::complex<double>, 1, 4> dds_, dsi_, dsf_, s_;
+  // Error in WKB series
+  Eigen::Matrix<std::complex<double>, 1, 4> s_error;
+  // WKB solutions and their derivatives
+  std::complex<double> fp_, fm_, dfpi_, dfmi_, dfpf_, dfmf_, ddfp_, ddfm_, ap_,
+      am_, bp_, bm_;
+  // step and stepsize
+  double h;
+  std::complex<double> x, dx, ddx;
+  // order
+  int order_;
+  // error estimate on step
+  std::complex<double> err_fp, err_fm, err_dfp, err_dfm;
+  // dense output
+  std::list<std::complex<double>> doxs, dodxs, dows;
+  Eigen::Matrix<std::complex<double>, 1, 4> dense_s_, dense_ds_, dense_ds_i;
+  std::complex<double> dense_ap_, dense_am_, dense_bp_, dense_bm_;
+  // experimental dense output + quadrature
+  Eigen::Matrix<double, 6, 6> integ_vandermonde, interp_vandermonde;
 
-    public:
-    // constructor
-    WKBSolver();
-    WKBSolver(de_system &de_sys, int order);
-    Eigen::Matrix<std::complex<double>,3,2> step(std::complex<double> x0,
-    std::complex<double> dx0, double t0, double h0, const
-    Eigen::Matrix<std::complex<double>,6,1> &ws, const
-    Eigen::Matrix<std::complex<double>,6,1> &gs, const
-    Eigen::Matrix<std::complex<double>,5,1> &ws5, const
-    Eigen::Matrix<std::complex<double>,5,1> &gs5); 
-    // dense output
-    void dense_step(double t0, const std::list<double> &dots, std::list<std::complex<double>> &doxs, std::list<std::complex<double>> &dodxs);
-    Eigen::Matrix<double,6,1> dense_weights_6(double t);
-    Eigen::Matrix<double,6,1> dense_weights_derivs_6(double t);
-    std::complex<double> dense_integrate(const Eigen::Matrix<double,6,1>
-    &denseweights6, const Eigen::Matrix<std::complex<double>,6,1> &integrand6);
-    std::complex<double> dense_interpolate(const Eigen::Matrix<double,6,1>
-    &denseweights6, const Eigen::Matrix<std::complex<double>,6,1> &integrand6);
-    // Experimental continuous representation of solution
-    Eigen::Matrix<std::complex<double>,7,1> x_vdm;
-
-
+public:
+  // constructor
+  WKBSolver();
+  WKBSolver(de_system &de_sys, int order);
+  Eigen::Matrix<std::complex<double>, 3, 2>
+  step(std::complex<double> x0, std::complex<double> dx0, double t0, double h0,
+       const Eigen::Matrix<std::complex<double>, 6, 1> &ws,
+       const Eigen::Matrix<std::complex<double>, 6, 1> &gs,
+       const Eigen::Matrix<std::complex<double>, 5, 1> &ws5,
+       const Eigen::Matrix<std::complex<double>, 5, 1> &gs5);
+  // dense output
+  void dense_step(double t0, const std::list<double> &dots,
+                  std::list<std::complex<double>> &doxs,
+                  std::list<std::complex<double>> &dodxs);
+  Eigen::Matrix<double, 6, 1> dense_weights_6(double t);
+  Eigen::Matrix<double, 6, 1> dense_weights_derivs_6(double t);
+  std::complex<double>
+  dense_integrate(const Eigen::Matrix<double, 6, 1> &denseweights6,
+                  const Eigen::Matrix<std::complex<double>, 6, 1> &integrand6);
+  std::complex<double> dense_interpolate(
+      const Eigen::Matrix<double, 6, 1> &denseweights6,
+      const Eigen::Matrix<std::complex<double>, 6, 1> &integrand6);
+  // Experimental continuous representation of solution
+  Eigen::Matrix<std::complex<double>, 7, 1> x_vdm;
 };
 
-WKBSolver::WKBSolver(){
-};
+WKBSolver::WKBSolver(){};
 
-WKBSolver::WKBSolver(de_system &de_sys, int order){
+WKBSolver::WKBSolver(de_system &de_sys, int order) {
 
-    // Set order
-    order_ = order;
-    // Set Gauss-Lobatto weights
-    glws6 << 1.0/15.0,0.3784749562978469803166,0.5548583770354863530167,
-        0.5548583770354863530167,0.3784749562978469803166,1.0/15.0;
-    glws5 << 1.0/10.0,49.0/90.0,32.0/45.0,49.0/90.0,1.0/10.0;
-    // Set finite difference weights
-    d1w1_w << -15.0000000048537, 20.2828318761850,
-        -8.07237453994912, 4.48936929577350, -2.69982662677053, 0.999999999614819;
-    d1w2_w << -3.57272991033049, 0.298532922755350e-7  ,
-        5.04685352597795, -2.30565629452303, 1.30709499910514, -0.475562350082855;
-    d1w3_w << 0.969902096162109, -3.44251390568294,
-    -0.781532641131861e-10, 3.50592393061265, -1.57271334190619, 0.539401220892526 ;
-    d1w4_w << -0.539401220892533, 1.57271334190621,
-        -3.50592393061268, 0.782075077478921e-10, 3.44251390568290, -0.969902096162095;
-    d1w5_w << 0.475562350082834, -1.30709499910509,
-        2.30565629452296, -5.04685352597787, -0.298533681980831e-7, 3.57272991033053;
-    d1w6_w << -0.999999999614890, 2.69982662677075,
-        -4.48936929577383, 8.07237453994954, -20.2828318761854, 15.0000000048538;
-    d2w1_w << 140.000000016641, -263.163968874741,
-        196.996471291466, -120.708905753218, 74.8764032980854, -27.9999999782328;
-    d2w2_w <<  60.8267436465252, -96.4575130414144, 42.0725563562029,
-        -8.78105375967028, 3.41699471496020, -1.07772791660362; 
-    d2w3_w << -5.42778322782674, 28.6981500482483, -43.5424868874619,
-        24.5830052399403, -5.98965265951073, 1.67876748661075;
-    d2w4_w << 1.67876748661071, -5.98965265951067, 24.5830052399402,
-        -43.5424868874617, 28.6981500482481, -5.42778322782664;
-    d2w5_w << -1.07772791660381, 3.41699471496078, -8.78105375967105,
-        42.0725563562040, -96.4575130414154, 60.8267436465256;
-    d2w6_w << -27.9999999782335, 74.8764032980873, -120.708905753221,
-        196.996471291469, -263.163968874744, 140.000000016642;
-    d3w1_w << -840.000000234078, 1798.12714381468, -1736.74461287884,
-        1322.01528240287, -879.397812956524, 335.999999851893;
-    d3w2_w << -519.5390172614027, 1067.7171515309801, -934.3207515371753,
-        617.0298708048756, -364.83838902593686, 133.95113548865842;
-    d3w3_w << -81.13326349151461, 90.82824880172825, 81.1176254157912,
-        -199.41150112141258, 171.22231114098616, -62.62342074557803;
-    d3w4_w << 62.62342074557783, -171.2223111409866, 199.41150112141344,
-        -81.11762541579242, -90.82824880172696, 81.13326349151436;
-    d3w5_w << -133.95113548865962, 364.8383890259409, -617.0298708048813,
-        934.3207515371842, -1067.717151530989, 519.5390172614059;
-    d3w6_w << -335.999999851897, 879.397812956534,
-        -1322.01528240289, 1736.74461287886, -1798.12714381470, 840.000000234086;
-    d4w1_w << //9744.00062637928, -27851.6858893579, 75653.4044616243,
-        //-107520.008443354, 61113.3089030151, -15843.0200709916, 4704.00041268436;
-            3024.00000383582, -6923.06197480357, 7684.77676018742, 0.0, -6855.31809730784, 5085.60330881706, -2016.00000072890;
-    d1g1_w << -15.0000000048537, 20.2828318761850,
-    -8.07237453994912, 4.48936929577350, -2.69982662677053, 0.999999999614819 ;
-    d1g6_w << -0.999999999614890, 2.69982662677075,
-        -4.48936929577383, 8.07237453994954, -20.2828318761854, 15.0000000048538;
-    d2g1_w << 140.000000016641, -263.163968874741,
-        196.996471291466, -120.708905753218, 74.8764032980854, -27.9999999782328;
-    d2g6_w << -27.9999999782335, 74.8764032980873,
-        -120.708905753221, 196.996471291469, -263.163968874744, 140.000000016642;
-    d3g1_w << -840.000000234078, 1798.12714381468,
-        -1736.74461287884, 1322.01528240287, -879.397812956524, 335.999999851893;
-    d1w2_5_w << -2.48198050935042, 0.560400997591235e-8,
-        3.49148624058567, -1.52752523062733, 0.518019493788063;
-    d1w3_5_w << 0.750000000213852, -2.67316915534181,
-        0.360673032443906e-10, 2.67316915534181, -0.750000000213853;
-    d1w4_5_w << -0.518019493788065, 1.52752523062733,
-        -3.49148624058568, -0.560400043118500e-8, 2.48198050935041;
-    // Set polynomial Gauss--Lobatto coefficients for dense output + quadrature
-    double a = std::sqrt(147+42*std::sqrt(7.));
-    double b = std::sqrt(147-42*std::sqrt(7.));
+  // Set order
+  order_ = order;
+  // Set Gauss-Lobatto weights
+  glws6 << 1.0 / 15.0, 0.3784749562978469803166, 0.5548583770354863530167,
+      0.5548583770354863530167, 0.3784749562978469803166, 1.0 / 15.0;
+  glws5 << 1.0 / 10.0, 49.0 / 90.0, 32.0 / 45.0, 49.0 / 90.0, 1.0 / 10.0;
+  // Set finite difference weights
+  d1w1_w << -15.0000000048537, 20.2828318761850, -8.07237453994912,
+      4.48936929577350, -2.69982662677053, 0.999999999614819;
+  d1w2_w << -3.57272991033049, 0.298532922755350e-7, 5.04685352597795,
+      -2.30565629452303, 1.30709499910514, -0.475562350082855;
+  d1w3_w << 0.969902096162109, -3.44251390568294, -0.781532641131861e-10,
+      3.50592393061265, -1.57271334190619, 0.539401220892526;
+  d1w4_w << -0.539401220892533, 1.57271334190621, -3.50592393061268,
+      0.782075077478921e-10, 3.44251390568290, -0.969902096162095;
+  d1w5_w << 0.475562350082834, -1.30709499910509, 2.30565629452296,
+      -5.04685352597787, -0.298533681980831e-7, 3.57272991033053;
+  d1w6_w << -0.999999999614890, 2.69982662677075, -4.48936929577383,
+      8.07237453994954, -20.2828318761854, 15.0000000048538;
+  d2w1_w << 140.000000016641, -263.163968874741, 196.996471291466,
+      -120.708905753218, 74.8764032980854, -27.9999999782328;
+  d2w2_w << 60.8267436465252, -96.4575130414144, 42.0725563562029,
+      -8.78105375967028, 3.41699471496020, -1.07772791660362;
+  d2w3_w << -5.42778322782674, 28.6981500482483, -43.5424868874619,
+      24.5830052399403, -5.98965265951073, 1.67876748661075;
+  d2w4_w << 1.67876748661071, -5.98965265951067, 24.5830052399402,
+      -43.5424868874617, 28.6981500482481, -5.42778322782664;
+  d2w5_w << -1.07772791660381, 3.41699471496078, -8.78105375967105,
+      42.0725563562040, -96.4575130414154, 60.8267436465256;
+  d2w6_w << -27.9999999782335, 74.8764032980873, -120.708905753221,
+      196.996471291469, -263.163968874744, 140.000000016642;
+  d3w1_w << -840.000000234078, 1798.12714381468, -1736.74461287884,
+      1322.01528240287, -879.397812956524, 335.999999851893;
+  d3w2_w << -519.5390172614027, 1067.7171515309801, -934.3207515371753,
+      617.0298708048756, -364.83838902593686, 133.95113548865842;
+  d3w3_w << -81.13326349151461, 90.82824880172825, 81.1176254157912,
+      -199.41150112141258, 171.22231114098616, -62.62342074557803;
+  d3w4_w << 62.62342074557783, -171.2223111409866, 199.41150112141344,
+      -81.11762541579242, -90.82824880172696, 81.13326349151436;
+  d3w5_w << -133.95113548865962, 364.8383890259409, -617.0298708048813,
+      934.3207515371842, -1067.717151530989, 519.5390172614059;
+  d3w6_w << -335.999999851897, 879.397812956534, -1322.01528240289,
+      1736.74461287886, -1798.12714381470, 840.000000234086;
+  d4w1_w << // 9744.00062637928, -27851.6858893579, 75653.4044616243,
+            //-107520.008443354, 61113.3089030151, -15843.0200709916,
+            //4704.00041268436;
+      3024.00000383582,
+      -6923.06197480357, 7684.77676018742, 0.0, -6855.31809730784,
+      5085.60330881706, -2016.00000072890;
+  d1g1_w << -15.0000000048537, 20.2828318761850, -8.07237453994912,
+      4.48936929577350, -2.69982662677053, 0.999999999614819;
+  d1g6_w << -0.999999999614890, 2.69982662677075, -4.48936929577383,
+      8.07237453994954, -20.2828318761854, 15.0000000048538;
+  d2g1_w << 140.000000016641, -263.163968874741, 196.996471291466,
+      -120.708905753218, 74.8764032980854, -27.9999999782328;
+  d2g6_w << -27.9999999782335, 74.8764032980873, -120.708905753221,
+      196.996471291469, -263.163968874744, 140.000000016642;
+  d3g1_w << -840.000000234078, 1798.12714381468, -1736.74461287884,
+      1322.01528240287, -879.397812956524, 335.999999851893;
+  d1w2_5_w << -2.48198050935042, 0.560400997591235e-8, 3.49148624058567,
+      -1.52752523062733, 0.518019493788063;
+  d1w3_5_w << 0.750000000213852, -2.67316915534181, 0.360673032443906e-10,
+      2.67316915534181, -0.750000000213853;
+  d1w4_5_w << -0.518019493788065, 1.52752523062733, -3.49148624058568,
+      -0.560400043118500e-8, 2.48198050935041;
+  // Set polynomial Gauss--Lobatto coefficients for dense output + quadrature
+  double a = std::sqrt(147 + 42 * std::sqrt(7.));
+  double b = std::sqrt(147 - 42 * std::sqrt(7.));
 
-    interp_vandermonde << 0.06250000000, -0.1946486424, 0.6321486424, 0.6321486424, -0.1946486424, 0.06250000000,
-              -0.06250000000, 0.2544242701, -2.216265054, 2.216265054, -0.2544242701, 0.06250000000,
-               -0.8750000000, 2.587172940, -1.712172940, -1.712172940, 2.587172940, -0.8750000000,
-                0.8750000000, -3.381680853, 6.002748088, -6.002748088, 3.381680853, -0.8750000000,
-                 1.312500000, -2.392524298, 1.080024298, 1.080024298, -2.392524298, 1.312500000,
-                  -1.312500000, 3.127256583, -3.786483034, 3.786483034, -3.127256583, 1.312500000;
+  interp_vandermonde << 0.06250000000, -0.1946486424, 0.6321486424,
+      0.6321486424, -0.1946486424, 0.06250000000, -0.06250000000, 0.2544242701,
+      -2.216265054, 2.216265054, -0.2544242701, 0.06250000000, -0.8750000000,
+      2.587172940, -1.712172940, -1.712172940, 2.587172940, -0.8750000000,
+      0.8750000000, -3.381680853, 6.002748088, -6.002748088, 3.381680853,
+      -0.8750000000, 1.312500000, -2.392524298, 1.080024298, 1.080024298,
+      -2.392524298, 1.312500000, -1.312500000, 3.127256583, -3.786483034,
+      3.786483034, -3.127256583, 1.312500000;
 
-   
-    integ_vandermonde << 0.06250000000, -0.1946486424, 0.6321486424, 0.6321486424, -0.1946486424, 0.06250000000,
-              -0.03125000000, 0.1272121350, -1.108132527, 1.108132527, -0.1272121350, 0.03125000000,
-               -0.2916666667, 0.8623909801, -0.5707243134, -0.5707243134, 0.8623909801, -0.2916666667,
-                0.2187500000, -0.8454202132, 1.500687022, -1.500687022, 0.8454202132, -0.2187500000,
-                 0.2625000000, -0.4785048596, 0.2160048596, 0.2160048596, -0.4785048596, 0.2625000000,
-                  -0.2187500000, 0.5212094304, -0.6310805056, 0.6310805056, -0.5212094304, 0.2187500000;
- 
-
+  integ_vandermonde << 0.06250000000, -0.1946486424, 0.6321486424, 0.6321486424,
+      -0.1946486424, 0.06250000000, -0.03125000000, 0.1272121350, -1.108132527,
+      1.108132527, -0.1272121350, 0.03125000000, -0.2916666667, 0.8623909801,
+      -0.5707243134, -0.5707243134, 0.8623909801, -0.2916666667, 0.2187500000,
+      -0.8454202132, 1.500687022, -1.500687022, 0.8454202132, -0.2187500000,
+      0.2625000000, -0.4785048596, 0.2160048596, 0.2160048596, -0.4785048596,
+      0.2625000000, -0.2187500000, 0.5212094304, -0.6310805056, 0.6310805056,
+      -0.5212094304, 0.2187500000;
 };
 
 /** Computes a WKB step of a given order and returns the solution and its local
- * error estimate. 
+ * error estimate.
  *
  *
  * @param x0[in] value of the solution \f$x(t)\f$ at the start of the step
@@ -228,7 +236,7 @@ WKBSolver::WKBSolver(de_system &de_sys, int order){
  * @param ws[in] vector of 6 evaulations of the frequency term at the
  * Gauss-Lobatto nodes, this is necessary for Gauss-Lobatto integration, which
  * in turn is needed to calculate the WKB series
- * @param gs[in] vector of 6 evaluations of the friction term 
+ * @param gs[in] vector of 6 evaluations of the friction term
  * @param ws5[in] vector of 5 evaluations of the friction term at the nodes of
  * 5th order Gauss-Lobatto quadrature, this is needed to compute the error on
  * Gauss-Lobatto quadrature, and in turn the WKB series
@@ -236,129 +244,178 @@ WKBSolver::WKBSolver(de_system &de_sys, int order){
  *
  * @returns a matrix, whose rows are:
  * - \f$ x, \dot{x}\f$ at t0+h0 as an nth order WKB estimate
- * - \f$ \Delta_{\mathrm{trunc}}x, \Delta_{\mathrm{trunc}}\dot{x}\f$ at t0+h0, defined as the difference between
- *   an nth and (n-1)th order WKB estimate
+ * - \f$ \Delta_{\mathrm{trunc}}x, \Delta_{\mathrm{trunc}}\dot{x}\f$ at t0+h0,
+ * defined as the difference between an nth and (n-1)th order WKB estimate
  * - \f$ \Delta_{\mathrm{int}}x, \Delta_{\mathrm{int}}\dot{x}\f$ at t0+h0,
  *   defined as the local error coming from those terms in the WKB series that
  *   involved numerical integrals
  */
-Eigen::Matrix<std::complex<double>,3,2> WKBSolver::step(std::complex<double> x0,
-std::complex<double> dx0, double t0, double h0, const
-Eigen::Matrix<std::complex<double>,6,1> &ws, const
-Eigen::Matrix<std::complex<double>,6,1> &gs, const
-Eigen::Matrix<std::complex<double>,5,1> &ws5, const
-Eigen::Matrix<std::complex<double>,5,1> &gs5){
+Eigen::Matrix<std::complex<double>, 3, 2>
+WKBSolver::step(std::complex<double> x0, std::complex<double> dx0, double t0,
+                double h0, const Eigen::Matrix<std::complex<double>, 6, 1> &ws,
+                const Eigen::Matrix<std::complex<double>, 6, 1> &gs,
+                const Eigen::Matrix<std::complex<double>, 5, 1> &ws5,
+                const Eigen::Matrix<std::complex<double>, 5, 1> &gs5) {
 
+  // Vandermonde dense output
+  Eigen::Matrix<std::complex<double>, 6, 1> s0_vdm_vec, s1_vdm_vec, s2_vdm_vec,
+      s3_vdm_vec;
+  std::complex<double> s0_vdm, s1_vdm, s2_vdm, s3_vdm;
+  Eigen::Matrix<std::complex<double>, 7, 1> s_vdm_vec;
+  Eigen::Matrix<double, 6, 1> dows6,
+      dodws6; // weights for dense integration/interpolation
+  Eigen::Matrix<std::complex<double>, 6, 1> integrand6, s3_interp, s2_interp,
+      s1_interp;
+  Eigen::Matrix<std::complex<double>, 6, 1> ds1_interp, ds2_interp, ds3_interp;
+  double t_trans;
+  std::complex<double> s0, s1, s2, s3, dense_fp, dense_fm, dense_x;
+  std::complex<double> ds0, ds1, ds2, ds3, dense_dfpf, dense_dfmf, dense_dx;
 
-    // Vandermonde dense output
-    Eigen::Matrix<std::complex<double>,6,1> s0_vdm_vec,s1_vdm_vec,s2_vdm_vec,s3_vdm_vec;
-    std::complex<double> s0_vdm,s1_vdm,s2_vdm,s3_vdm;
-    Eigen::Matrix<std::complex<double>,7,1> s_vdm_vec;
-    Eigen::Matrix<double,6,1> dows6, dodws6; // weights for dense integration/interpolation
-    Eigen::Matrix<std::complex<double>,6,1> integrand6, s3_interp, s2_interp, s1_interp;
-    Eigen::Matrix<std::complex<double>,6,1> ds1_interp, ds2_interp, ds3_interp; 
-    double t_trans;
-    std::complex<double> s0,s1,s2,s3,dense_fp,dense_fm,dense_x;
-    std::complex<double> ds0,ds1,ds2,ds3,dense_dfpf,dense_dfmf,dense_dx;
+  Eigen::Matrix<std::complex<double>, 3, 2> result;
+  result << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+  // Set grid of ws, gs:
+  ws_ = ws;
+  gs_ = gs;
+  ws5_ = ws5;
+  gs5_ = gs5;
+  ws7_ << ws_(0), ws_(1), ws_(2), ws5_(2), ws_(3), ws_(4), ws_(5);
+  // Set i.c.
+  x = x0;
+  dx = dx0;
+  ddx = -std::pow(ws_(0), 2) * x - 2.0 * gs_(0) * dx;
+  // Set derivatives:
+  h = h0;
+  d1w1();
+  d1w2();
+  d1w3();
+  d1w4();
+  d1w5();
+  d1w6();
+  d2w1();
+  d2w6();
+  d3w1();
+  d3w6();
+  d4w1();
+  d1g1();
+  d1g6();
+  d2g1();
+  d2g6();
+  d3g1();
+  d1w2_5();
+  d1w3_5();
+  d1w4_5();
+  dws_ << d1w1_, d1w2_, d1w3_, d1w4_, d1w5_, d1w6_;
+  dws5_ << d1w1_, d1w2_5_, d1w3_5_, d1w4_5_, d1w6_;
+  // Higher order step
+  // Calculate A, B
+  fm_ = 1.0;
+  fp_ = 1.0;
+  s_ << 0.0, 0.0, 0.0, 0.0;
+  dsi();
+  dds();
+  dfpi();
+  dfmi();
+  ddfp();
+  ddfm();
+  ap();
+  am();
+  bp();
+  bm();
+  dense_ap_ = ap_;
+  dense_am_ = am_;
+  dense_bp_ = bp_;
+  dense_bm_ = bm_;
+  dense_ds_i = dsi_;
+  // Calculate step
+  s();
+  dsf();
+  fp();
+  fm();
+  dfpf();
+  dfmf();
+  result(0, 0) = ap_ * fp_ + am_ * fm_;
+  result(0, 1) = bp_ * dfpf_ + bm_ * dfmf_;
+  // Error estimate on this
+  err_fp = s_error.cwiseAbs().sum() * fp_;
+  err_fm = std::conj(err_fp);
+  err_dfp = dfpf_ / fp_ * err_fp;
+  err_dfm = std::conj(err_dfp);
+  result(2, 0) = ap_ * err_fp + am_ * err_fm;
+  result(2, 1) = bp_ * err_dfp + bm_ * err_dfm;
 
+  // Experimental continuous representation
+  // Compute some derivatives only necessary for dense output
+  d1g2();
+  d1g3();
+  d1g4();
+  d1g5();
+  d2w2();
+  d2w3();
+  d2w4();
+  d2w5();
+  dgs_ << d1g1_, d1g2_, d1g3_, d1g4_, d1g5_, d1g6_;
+  d2ws_ << d2w1_, d2w2_, d2w3_, d2w4_, d2w5_, d2w6_;
 
-    
-    Eigen::Matrix<std::complex<double>,3,2> result;
-    result << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
-    // Set grid of ws, gs:
-    ws_ = ws;
-    gs_ = gs;
-    ws5_ = ws5;
-    gs5_ = gs5;
-    ws7_ << ws_(0), ws_(1), ws_(2), ws5_(2), ws_(3), ws_(4), ws_(5);
-    // Set i.c.
-    x = x0;
-    dx = dx0;
-    ddx = -std::pow(ws_(0),2)*x - 2.0*gs_(0)*dx;
-    // Set derivatives:
-    h = h0;
-    d1w1(); d1w2(); d1w3(); d1w4(); d1w5(); d1w6(); d2w1(); d2w6(); d3w1();
-    d3w6(); d4w1(); d1g1(); d1g6(); d2g1(); d2g6(); d3g1(); d1w2_5(); d1w3_5(); d1w4_5();
-    dws_ << d1w1_, d1w2_, d1w3_, d1w4_, d1w5_, d1w6_;
-    dws5_ << d1w1_, d1w2_5_, d1w3_5_, d1w4_5_, d1w6_;
-    // Higher order step
-        // Calculate A, B
-        fm_ = 1.0;
-        fp_ = 1.0;
-        s_ << 0.0, 0.0, 0.0, 0.0; dsi(); dds();
-        dfpi(); dfmi();
-        ddfp(); ddfm();
-        ap(); am(); bp(); bm();
-        dense_ap_ = ap_; dense_am_ = am_;
-        dense_bp_ = bp_; dense_bm_ = bm_;
-        dense_ds_i = dsi_;
-        // Calculate step
-        s(); 
-        dsf();
-        fp(); fm(); 
-        dfpf(); dfmf();
-        result(0,0) = ap_*fp_ + am_*fm_;
-        result(0,1) = bp_*dfpf_ +bm_*dfmf_;
-    // Error estimate on this
-        err_fp = s_error.cwiseAbs().sum()*fp_;
-        err_fm = std::conj(err_fp);
-        err_dfp = dfpf_/fp_*err_fp; 
-        err_dfm = std::conj(err_dfp);
-        result(2,0) = ap_*err_fp + am_*err_fm;
-        result(2,1) = bp_*err_dfp + bm_*err_dfm;
-    
-    // Experimental continuous representation
-        // Compute some derivatives only necessary for dense output
-        d1g2(); d1g3(); d1g4(); d1g5(); d2w2(); d2w3(); d2w4(); d2w5();
-        dgs_ << d1g1_, d1g2_, d1g3_, d1g4_, d1g5_, d1g6_;
-        d2ws_ << d2w1_, d2w2_, d2w3_, d2w4_, d2w5_, d2w6_;      
-        
-        integrand6 = 4.0*gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
-        4.0*dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
-        dws_.cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
-        for(int i=0; i<=5; i++)
-            s1_interp(i) = -1./2*std::log(ws_(i));
-        s2_interp = -1/4.0*(dws_.cwiseQuotient(ws_.cwiseProduct(ws_)) + 2.0*gs_.cwiseQuotient(ws_));
-        s3_interp =
-        1/4.0*(gs_.cwiseProduct(gs_).cwiseQuotient((ws_.cwiseProduct(ws_)))) +
-        1/4.0*(dgs_.cwiseQuotient(ws_.cwiseProduct(ws_))) -
-        3/16.0*(dws_.cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_).cwiseProduct(ws_.cwiseProduct(ws_))))
-        + 1/8.0*(d2ws_.cwiseQuotient(ws_.cwiseProduct(ws_).cwiseProduct(ws_)));
-       
-        // S0
-        s0_vdm_vec = h/2.0*std::complex<double>(0,1)*integ_vandermonde*ws_;
-        // S1
-        s1_vdm_vec = -h/2.0*integ_vandermonde*gs_;
-        s1_vdm_vec.head(5) += (interp_vandermonde*s1_interp).tail(5);
-        // S2
-        s2_vdm_vec = -h/2.0*1/8.0*integ_vandermonde*integrand6;
-        s2_vdm_vec.head(5) += (interp_vandermonde*s2_interp).tail(5);
-        // S3
-        s3_vdm_vec = Eigen::Matrix<std::complex<double>,6,1>::Zero(); 
-        s3_vdm_vec.head(5) += (interp_vandermonde*s3_interp).tail(5);
-        
-        x_vdm.tail(6) = s0_vdm_vec + s1_vdm_vec + std::complex<double>(0,1)*s2_vdm_vec + s3_vdm_vec; 
-        x_vdm(0) = ap_;
+  integrand6 =
+      4.0 * gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
+      4.0 * dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
+      dws_.cwiseProduct(dws_).cwiseQuotient(
+          ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
+  for (int i = 0; i <= 5; i++)
+    s1_interp(i) = -1. / 2 * std::log(ws_(i));
+  s2_interp = -1 / 4.0 *
+              (dws_.cwiseQuotient(ws_.cwiseProduct(ws_)) +
+               2.0 * gs_.cwiseQuotient(ws_));
+  s3_interp =
+      1 / 4.0 * (gs_.cwiseProduct(gs_).cwiseQuotient((ws_.cwiseProduct(ws_)))) +
+      1 / 4.0 * (dgs_.cwiseQuotient(ws_.cwiseProduct(ws_))) -
+      3 / 16.0 *
+          (dws_.cwiseProduct(dws_).cwiseQuotient(
+              ws_.cwiseProduct(ws_).cwiseProduct(ws_.cwiseProduct(ws_)))) +
+      1 / 8.0 * (d2ws_.cwiseQuotient(ws_.cwiseProduct(ws_).cwiseProduct(ws_)));
 
-        
-    // Lower order step for correction
-        // A, B
-        dsi_(order_) = 0.0; dds_(order_) = 0.0;
-        dfpi(); dfmi();
-        ddfp(); ddfm();
-        ap(); am(); bp(); bm();
-        // Calculate step
-        s_(order_) = 0.0;
-        dsf_(order_) = 0.0;
-        fp(); fm();
-        dfpf(); dfmf();
-        result(1,0) = result(0,0) - ap_*fp_ - am_*fm_;
-        result(1,1) = result(0,1) - bp_*dfpf_ - bm_*dfmf_;
+  // S0
+  s0_vdm_vec = h / 2.0 * std::complex<double>(0, 1) * integ_vandermonde * ws_;
+  // S1
+  s1_vdm_vec = -h / 2.0 * integ_vandermonde * gs_;
+  s1_vdm_vec.head(5) += (interp_vandermonde * s1_interp).tail(5);
+  // S2
+  s2_vdm_vec = -h / 2.0 * 1 / 8.0 * integ_vandermonde * integrand6;
+  s2_vdm_vec.head(5) += (interp_vandermonde * s2_interp).tail(5);
+  // S3
+  s3_vdm_vec = Eigen::Matrix<std::complex<double>, 6, 1>::Zero();
+  s3_vdm_vec.head(5) += (interp_vandermonde * s3_interp).tail(5);
 
-    return result;
+  x_vdm.tail(6) = s0_vdm_vec + s1_vdm_vec +
+                  std::complex<double>(0, 1) * s2_vdm_vec + s3_vdm_vec;
+  x_vdm(0) = ap_;
+
+  // Lower order step for correction
+  // A, B
+  dsi_(order_) = 0.0;
+  dds_(order_) = 0.0;
+  dfpi();
+  dfmi();
+  ddfp();
+  ddfm();
+  ap();
+  am();
+  bp();
+  bm();
+  // Calculate step
+  s_(order_) = 0.0;
+  dsf_(order_) = 0.0;
+  fp();
+  fm();
+  dfpf();
+  dfmf();
+  result(1, 0) = result(0, 0) - ap_ * fp_ - am_ * fm_;
+  result(1, 1) = result(0, 1) - bp_ * dfpf_ - bm_ * dfmf_;
+
+  return result;
 };
 
-/** Computes dense output at a set of timepoints within a step. 
+/** Computes dense output at a set of timepoints within a step.
  *
  * @param t0[in] value of independent variable (time) at the start of the step
  * @param dots[in] sequence of timepoints at which dense output is to be
@@ -367,581 +424,619 @@ Eigen::Matrix<std::complex<double>,5,1> &gs5){
  * @param dodxs[in,out] dense output for the derivative of the solution
  * \f$\dot{x}\f$
  */
-void WKBSolver::dense_step(double t0, const std::list<double> &dots, std::list<std::complex<double>> &doxs, std::list<std::complex<double>> &dodxs){
+void WKBSolver::dense_step(double t0, const std::list<double> &dots,
+                           std::list<std::complex<double>> &doxs,
+                           std::list<std::complex<double>> &dodxs) {
 
-    // We have: ws_, gs_, ws5_, gs5_, ws7_, x, dx, ddx, h, dws_, dws5_, d2wx,
-    // d3wx, etc., 
-    
-    int docount = dots.size();
-    doxs.resize(docount);
-    dodxs.resize(docount);
-    Eigen::Matrix<double,6,1> dows6, dodws6; // weights for dense integration/interpolation
-    Eigen::Matrix<std::complex<double>,6,1> integrand6, s3_interp, s2_interp, s1_interp;
-    Eigen::Matrix<std::complex<double>,6,1> ds1_interp, ds2_interp, ds3_interp; 
-    double t_trans;
-    std::complex<double> s0,s1,s2,s3,dense_fp,dense_fm,dense_x;
-    std::complex<double> ds0,ds1,ds2,ds3,dense_dfpf,dense_dfmf,dense_dx;
-    // Vandermonde dense output
-    Eigen::Matrix<std::complex<double>,6,1> s0_vdm_vec,s1_vdm_vec,s2_vdm_vec,s3_vdm_vec;
-    Eigen::Matrix<double,6,1> t_trans_vec,t_trans_vec_interp;
-    std::complex<double> s0_vdm,s1_vdm,s2_vdm,s3_vdm;
-    Eigen::Matrix<std::complex<double>,7,1> s_vdm_vec;
-    double tt1,tt2,tt3,tt4,tt5,tt6;
+  // We have: ws_, gs_, ws5_, gs5_, ws7_, x, dx, ddx, h, dws_, dws5_, d2wx,
+  // d3wx, etc.,
 
-   
-    // Compute some derivatives only necessary for dense output
-    d1g2(); d1g3(); d1g4(); d1g5(); d2w2(); d2w3(); d2w4(); d2w5();
-    d2g2(); d2g3(); d2g4(); d2g5(); d3w2(); d3w3(); d3w4(); d3w5();
-    dgs_ << d1g1_, d1g2_, d1g3_, d1g4_, d1g5_, d1g6_;
-    d2ws_ << d2w1_, d2w2_, d2w3_, d2w4_, d2w5_, d2w6_;      
-    d2gs_ << d2g1_, d2g2_, d2g3_, d2g4_, d2g5_, d2g6_;
-    d3ws_ << d3w1_, d3w2_, d3w3_, d3w4_, d3w5_, d3w6_;
+  int docount = dots.size();
+  doxs.resize(docount);
+  dodxs.resize(docount);
+  Eigen::Matrix<double, 6, 1> dows6,
+      dodws6; // weights for dense integration/interpolation
+  Eigen::Matrix<std::complex<double>, 6, 1> integrand6, s3_interp, s2_interp,
+      s1_interp;
+  Eigen::Matrix<std::complex<double>, 6, 1> ds1_interp, ds2_interp, ds3_interp;
+  double t_trans;
+  std::complex<double> s0, s1, s2, s3, dense_fp, dense_fm, dense_x;
+  std::complex<double> ds0, ds1, ds2, ds3, dense_dfpf, dense_dfmf, dense_dx;
+  // Vandermonde dense output
+  Eigen::Matrix<std::complex<double>, 6, 1> s0_vdm_vec, s1_vdm_vec, s2_vdm_vec,
+      s3_vdm_vec;
+  Eigen::Matrix<double, 6, 1> t_trans_vec, t_trans_vec_interp;
+  std::complex<double> s0_vdm, s1_vdm, s2_vdm, s3_vdm;
+  Eigen::Matrix<std::complex<double>, 7, 1> s_vdm_vec;
+  double tt1, tt2, tt3, tt4, tt5, tt6;
 
-    // Loop over dense output points
-        auto doxit = doxs.begin();
-        auto dodxit = dodxs.begin();
-        for(auto it=dots.begin(); it!=dots.end(); it++){
-            // Transform intermediate points to be in (-1,1):
-            t_trans = 2*(*it - t0)/h - 1;
-            dows6 = dense_weights_6(t_trans);
-            dodws6 = dense_weights_derivs_6(t_trans);
-            
-            // Dense output x
-            integrand6 = 4.0*gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
-            4.0*dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
-            dws_.cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
-        
-            s0 = std::complex<double>(0,1)*dense_integrate(dows6,ws_);  
-            s1 = dense_integrate(dows6,gs_);
-            for(int i=0; i<=5; i++)
-                s1_interp(i) = -1./2*std::log(ws_(i));
-            s1 = dense_interpolate(dodws6, s1_interp) - s1;
-            s2 = dense_integrate(dows6, integrand6);
-            s2_interp = -1/4.0*(dws_.cwiseQuotient(ws_.cwiseProduct(ws_)) + 2.0*gs_.cwiseQuotient(ws_));
-            s2 = dense_interpolate(dodws6, s2_interp) - 1/8.0*s2;
-        
-            s3_interp =
-            1/4.0*(gs_.cwiseProduct(gs_).cwiseQuotient((ws_.cwiseProduct(ws_)))) +
-            1/4.0*(dgs_.cwiseQuotient(ws_.cwiseProduct(ws_))) -
-            3/16.0*(dws_.cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_).cwiseProduct(ws_.cwiseProduct(ws_))))
-            + 1/8.0*(d2ws_.cwiseQuotient(ws_.cwiseProduct(ws_).cwiseProduct(ws_)));
-            s3 = dense_interpolate(dodws6, s3_interp); 
-           
-            dense_s_ << s0, s1, std::complex<double>(0,1)*s2, s3;
-            dense_fp = std::exp(dense_s_.sum());
-            dense_fm = std::conj(dense_fp);
-            dense_x = dense_ap_*dense_fp + dense_am_*dense_fm;
-            *doxit = dense_x;
-            doxit++;
+  // Compute some derivatives only necessary for dense output
+  d1g2();
+  d1g3();
+  d1g4();
+  d1g5();
+  d2w2();
+  d2w3();
+  d2w4();
+  d2w5();
+  d2g2();
+  d2g3();
+  d2g4();
+  d2g5();
+  d3w2();
+  d3w3();
+  d3w4();
+  d3w5();
+  dgs_ << d1g1_, d1g2_, d1g3_, d1g4_, d1g5_, d1g6_;
+  d2ws_ << d2w1_, d2w2_, d2w3_, d2w4_, d2w5_, d2w6_;
+  d2gs_ << d2g1_, d2g2_, d2g3_, d2g4_, d2g5_, d2g6_;
+  d3ws_ << d3w1_, d3w2_, d3w3_, d3w4_, d3w5_, d3w6_;
 
-            // Same, but with Vandermonde matrix:
-            tt1 = t_trans; 
-            tt2 = tt1*t_trans;
-            tt3 = tt2*t_trans;
-            tt4 = tt3*t_trans;
-            tt5 = tt4*t_trans;
-            tt6 = tt5*t_trans;
-            t_trans_vec << tt1+1, tt2-1, tt3+1, tt4-1, tt5+1, tt6-1; 
-            t_trans_vec_interp << 0, tt1+1, tt2-1, tt3+1, tt4-1, tt5+1;
-            // S0
-            s0_vdm_vec = h/2.0*std::complex<double>(0,1)*integ_vandermonde*ws_;
-            s0_vdm = t_trans_vec.dot(s0_vdm_vec); 
-            // S1
-            s1_vdm = -h/2.0*t_trans_vec.dot(integ_vandermonde*gs_) + t_trans_vec_interp.dot(interp_vandermonde*s1_interp);
-            s1_vdm_vec = -h/2.0*integ_vandermonde*gs_;
-            s1_vdm_vec.head(5) += (interp_vandermonde*s1_interp).tail(5);
-            s1_vdm = t_trans_vec.dot(s1_vdm_vec);
-            // S2
-            s2_vdm_vec = -h/2.0*1/8.0*integ_vandermonde*integrand6;
-            s2_vdm_vec.head(5) += (interp_vandermonde*s2_interp).tail(5);
-            s2_vdm = t_trans_vec.dot(s2_vdm_vec);
-            // S3
-            s3_vdm_vec = Eigen::Matrix<std::complex<double>,6,1>::Zero(); 
-            s3_vdm_vec.head(5) += (interp_vandermonde*s3_interp).tail(5);
-            s3_vdm = t_trans_vec.dot(s3_vdm_vec) ;
-            //x_vdm = dense_ap_*(s0_vdm_vec + s1_vdm_vec + s2_vdm_vec + s3_vdm_vec); 
+  // Loop over dense output points
+  auto doxit = doxs.begin();
+  auto dodxit = dodxs.begin();
+  for (auto it = dots.begin(); it != dots.end(); it++) {
+    // Transform intermediate points to be in (-1,1):
+    t_trans = 2 * (*it - t0) / h - 1;
+    dows6 = dense_weights_6(t_trans);
+    dodws6 = dense_weights_derivs_6(t_trans);
 
-            //std::cout << std::setprecision(15) << "dense S0 with Vandermonde matrix: " << s0_vdm << std::endl;
-            //std::cout << "dense S0 with classical theory: " << s0 << std::endl;
-            //std::cout << std::setprecision(15) << "dense S1 with Vandermonde matrix: " << s1_vdm << std::endl;
-            //std::cout << "dense S1 with classical theory: " << s1 << std::endl;
-            //std::cout << std::setprecision(15) << "dense S2 with Vandermonde matrix: " << s2_vdm << std::endl;
-            //std::cout << "dense S1 with classical theory: " << s2 << std::endl;
-            //std::cout << std::setprecision(15) << "dense S3 with Vandermonde matrix: " << s3_vdm << std::endl;
-            //std::cout << "dense S3 with classical theory: " << s3 << std::endl;
+    // Dense output x
+    integrand6 =
+        4.0 * gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
+        4.0 * dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
+        dws_.cwiseProduct(dws_).cwiseQuotient(
+            ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
 
-            //std::cout << "Representation of S0: " << s0_vdm_vec << std::endl;
-            //std::cout << "Representation of S1: " << s1_vdm_vec << std::endl;
-            //std::cout << "Ap: " << dense_ap_ << ", Am: " << dense_am_ << std::endl;
+    s0 = std::complex<double>(0, 1) * dense_integrate(dows6, ws_);
+    s1 = dense_integrate(dows6, gs_);
+    for (int i = 0; i <= 5; i++)
+      s1_interp(i) = -1. / 2 * std::log(ws_(i));
+    s1 = dense_interpolate(dodws6, s1_interp) - s1;
+    s2 = dense_integrate(dows6, integrand6);
+    s2_interp = -1 / 4.0 *
+                (dws_.cwiseQuotient(ws_.cwiseProduct(ws_)) +
+                 2.0 * gs_.cwiseQuotient(ws_));
+    s2 = dense_interpolate(dodws6, s2_interp) - 1 / 8.0 * s2;
 
+    s3_interp =
+        1 / 4.0 *
+            (gs_.cwiseProduct(gs_).cwiseQuotient((ws_.cwiseProduct(ws_)))) +
+        1 / 4.0 * (dgs_.cwiseQuotient(ws_.cwiseProduct(ws_))) -
+        3 / 16.0 *
+            (dws_.cwiseProduct(dws_).cwiseQuotient(
+                ws_.cwiseProduct(ws_).cwiseProduct(ws_.cwiseProduct(ws_)))) +
+        1 / 8.0 *
+            (d2ws_.cwiseQuotient(ws_.cwiseProduct(ws_).cwiseProduct(ws_)));
+    s3 = dense_interpolate(dodws6, s3_interp);
 
-            // Dense output dx
-            ds0 = std::complex<double>(0,1)*dense_interpolate(dodws6,ws_);
-            ds1 = dense_interpolate(dodws6,gs_);
-            ds1_interp = -1./2*dws_.cwiseQuotient(ws_);
-            ds1 = dense_interpolate(dodws6,ds1_interp) - ds1;
-            ds2_interp = -1./2*gs_.cwiseProduct(gs_.cwiseQuotient(ws_)) - 1./2*dgs_.cwiseQuotient(ws_) + 3./8*(dws_.cwiseProduct(dws_)).cwiseQuotient((ws_.cwiseProduct(ws_)).cwiseProduct(ws_)) - 1./4*d2ws_.cwiseQuotient(ws_.cwiseProduct(ws_));
-            ds2 = dense_interpolate(dodws6,ds2_interp);
-            ds3_interp = 1./8.0*(d3ws_.cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_))) + 2*d2gs_.cwiseQuotient(ws_.cwiseProduct(ws_)) - 6*(dws_.cwiseProduct(d2ws_)).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_.cwiseProduct(ws_)))) + 6*(dws_.cwiseProduct(dws_.cwiseProduct(dws_))).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_.cwiseProduct(ws_.cwiseProduct(ws_))))) - 4*(gs_.cwiseProduct(gs_)+dgs_).cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_)))+ 4*dgs_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_.cwiseProduct(ws_)))));
-            ds3 = dense_interpolate(dodws6,ds3_interp); 
-            dense_ds_ << ds0, ds1, std::complex<double>(0,1)*ds2, ds3; 
-            dense_ds_ += dense_ds_i;
-            dense_dfpf = dense_ds_.sum()*dense_fp;
-            dense_dfmf = std::conj(dense_dfpf);
-            dense_dx = dense_bp_*dense_dfpf + dense_bm_*dense_dfmf;
-            *dodxit = dense_dx;
-            dodxit++;
-        }
-    
-    return;
+    dense_s_ << s0, s1, std::complex<double>(0, 1) * s2, s3;
+    dense_fp = std::exp(dense_s_.sum());
+    dense_fm = std::conj(dense_fp);
+    dense_x = dense_ap_ * dense_fp + dense_am_ * dense_fm;
+    *doxit = dense_x;
+    doxit++;
+
+    // Same, but with Vandermonde matrix:
+    tt1 = t_trans;
+    tt2 = tt1 * t_trans;
+    tt3 = tt2 * t_trans;
+    tt4 = tt3 * t_trans;
+    tt5 = tt4 * t_trans;
+    tt6 = tt5 * t_trans;
+    t_trans_vec << tt1 + 1, tt2 - 1, tt3 + 1, tt4 - 1, tt5 + 1, tt6 - 1;
+    t_trans_vec_interp << 0, tt1 + 1, tt2 - 1, tt3 + 1, tt4 - 1, tt5 + 1;
+    // S0
+    s0_vdm_vec = h / 2.0 * std::complex<double>(0, 1) * integ_vandermonde * ws_;
+    s0_vdm = t_trans_vec.dot(s0_vdm_vec);
+    // S1
+    s1_vdm = -h / 2.0 * t_trans_vec.dot(integ_vandermonde * gs_) +
+             t_trans_vec_interp.dot(interp_vandermonde * s1_interp);
+    s1_vdm_vec = -h / 2.0 * integ_vandermonde * gs_;
+    s1_vdm_vec.head(5) += (interp_vandermonde * s1_interp).tail(5);
+    s1_vdm = t_trans_vec.dot(s1_vdm_vec);
+    // S2
+    s2_vdm_vec = -h / 2.0 * 1 / 8.0 * integ_vandermonde * integrand6;
+    s2_vdm_vec.head(5) += (interp_vandermonde * s2_interp).tail(5);
+    s2_vdm = t_trans_vec.dot(s2_vdm_vec);
+    // S3
+    s3_vdm_vec = Eigen::Matrix<std::complex<double>, 6, 1>::Zero();
+    s3_vdm_vec.head(5) += (interp_vandermonde * s3_interp).tail(5);
+    s3_vdm = t_trans_vec.dot(s3_vdm_vec);
+    // x_vdm = dense_ap_*(s0_vdm_vec + s1_vdm_vec + s2_vdm_vec + s3_vdm_vec);
+
+    // std::cout << std::setprecision(15) << "dense S0 with Vandermonde matrix:
+    // " << s0_vdm << std::endl; std::cout << "dense S0 with classical theory: "
+    // << s0 << std::endl; std::cout << std::setprecision(15) << "dense S1 with
+    // Vandermonde matrix: " << s1_vdm << std::endl; std::cout << "dense S1 with
+    // classical theory: " << s1 << std::endl; std::cout <<
+    // std::setprecision(15) << "dense S2 with Vandermonde matrix: " << s2_vdm
+    // << std::endl; std::cout << "dense S1 with classical theory: " << s2 <<
+    // std::endl; std::cout << std::setprecision(15) << "dense S3 with
+    // Vandermonde matrix: " << s3_vdm << std::endl; std::cout << "dense S3 with
+    // classical theory: " << s3 << std::endl;
+
+    // std::cout << "Representation of S0: " << s0_vdm_vec << std::endl;
+    // std::cout << "Representation of S1: " << s1_vdm_vec << std::endl;
+    // std::cout << "Ap: " << dense_ap_ << ", Am: " << dense_am_ << std::endl;
+
+    // Dense output dx
+    ds0 = std::complex<double>(0, 1) * dense_interpolate(dodws6, ws_);
+    ds1 = dense_interpolate(dodws6, gs_);
+    ds1_interp = -1. / 2 * dws_.cwiseQuotient(ws_);
+    ds1 = dense_interpolate(dodws6, ds1_interp) - ds1;
+    ds2_interp =
+        -1. / 2 * gs_.cwiseProduct(gs_.cwiseQuotient(ws_)) -
+        1. / 2 * dgs_.cwiseQuotient(ws_) +
+        3. / 8 *
+            (dws_.cwiseProduct(dws_))
+                .cwiseQuotient((ws_.cwiseProduct(ws_)).cwiseProduct(ws_)) -
+        1. / 4 * d2ws_.cwiseQuotient(ws_.cwiseProduct(ws_));
+    ds2 = dense_interpolate(dodws6, ds2_interp);
+    ds3_interp =
+        1. / 8.0 *
+        (d3ws_.cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_))) +
+         2 * d2gs_.cwiseQuotient(ws_.cwiseProduct(ws_)) -
+         6 * (dws_.cwiseProduct(d2ws_))
+                 .cwiseQuotient(ws_.cwiseProduct(
+                     ws_.cwiseProduct(ws_.cwiseProduct(ws_)))) +
+         6 * (dws_.cwiseProduct(dws_.cwiseProduct(dws_)))
+                 .cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(
+                     ws_.cwiseProduct(ws_.cwiseProduct(ws_))))) -
+         4 * (gs_.cwiseProduct(gs_) + dgs_)
+                 .cwiseProduct(dws_)
+                 .cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_))) +
+         4 * dgs_.cwiseProduct(gs_).cwiseQuotient(
+                 ws_.cwiseProduct(ws_.cwiseProduct(ws_.cwiseProduct(ws_)))));
+    ds3 = dense_interpolate(dodws6, ds3_interp);
+    dense_ds_ << ds0, ds1, std::complex<double>(0, 1) * ds2, ds3;
+    dense_ds_ += dense_ds_i;
+    dense_dfpf = dense_ds_.sum() * dense_fp;
+    dense_dfmf = std::conj(dense_dfpf);
+    dense_dx = dense_bp_ * dense_dfpf + dense_bm_ * dense_dfmf;
+    *dodxit = dense_dx;
+    dodxit++;
+  }
+
+  return;
 };
 
 // Compute integration weights at a given point
-Eigen::Matrix<double,6,1> WKBSolver::dense_weights_6(double t){
+Eigen::Matrix<double, 6, 1> WKBSolver::dense_weights_6(double t) {
 
-    double a = std::sqrt(147+42*std::sqrt(7.));
-    double b = std::sqrt(147-42*std::sqrt(7.));
-    double c = (-2./35*t*t*t + 4./35*t*t - 2./45*t - 8./315)*std::sqrt(7.);
-    double w1 = 31./480 - 7./32*t*t*t*t*t*t + 21./80*t*t*t*t*t + 7./32*t*t*t*t -7./24*t*t*t - 1./32*t*t + 1./16*t;
-    double w2 = -2205*((c - 4./63*t + 8./63)*a + (t-1)*(t-1)*(t*t*std::sqrt(7.) + 1))*(t+1)*(t+1)/(a*(-1120 + 160*std::sqrt(7.)));
-    double w3 = -2205*((c + 4./63*t - 8./63)*b + (t-1)*(t-1)*(t*t*std::sqrt(7.) - 1))*(t+1)*(t+1)/(b*(1120 + 160*std::sqrt(7.)));
-    double w4 = 2205*((-c - 4./63*t + 8./63)*b + (t-1)*(t-1)*(t*t*std::sqrt(7.) - 1))*(t+1)*(t+1)/(b*(1120 + 160*std::sqrt(7.)));
-    double w5 = 2205*((-c + 4./63*t - 8./63)*a + (t-1)*(t-1)*(t*t*std::sqrt(7.) + 1))*(t+1)*(t+1)/(a*(-1120 + 160*std::sqrt(7.)));
-    double w6 = 1./480 + 7./32*t*t*t*t*t*t + 21./80*t*t*t*t*t - 7./32*t*t*t*t -7./24*t*t*t + 1./32*t*t + 1./16*t;
-    Eigen::Matrix<double,6,1> result;
-    result << w1,w2,w3,w4,w5,w6;
-    return result;
+  double a = std::sqrt(147 + 42 * std::sqrt(7.));
+  double b = std::sqrt(147 - 42 * std::sqrt(7.));
+  double c = (-2. / 35 * t * t * t + 4. / 35 * t * t - 2. / 45 * t - 8. / 315) *
+             std::sqrt(7.);
+  double w1 = 31. / 480 - 7. / 32 * t * t * t * t * t * t +
+              21. / 80 * t * t * t * t * t + 7. / 32 * t * t * t * t -
+              7. / 24 * t * t * t - 1. / 32 * t * t + 1. / 16 * t;
+  double w2 = -2205 *
+              ((c - 4. / 63 * t + 8. / 63) * a +
+               (t - 1) * (t - 1) * (t * t * std::sqrt(7.) + 1)) *
+              (t + 1) * (t + 1) / (a * (-1120 + 160 * std::sqrt(7.)));
+  double w3 = -2205 *
+              ((c + 4. / 63 * t - 8. / 63) * b +
+               (t - 1) * (t - 1) * (t * t * std::sqrt(7.) - 1)) *
+              (t + 1) * (t + 1) / (b * (1120 + 160 * std::sqrt(7.)));
+  double w4 = 2205 *
+              ((-c - 4. / 63 * t + 8. / 63) * b +
+               (t - 1) * (t - 1) * (t * t * std::sqrt(7.) - 1)) *
+              (t + 1) * (t + 1) / (b * (1120 + 160 * std::sqrt(7.)));
+  double w5 = 2205 *
+              ((-c + 4. / 63 * t - 8. / 63) * a +
+               (t - 1) * (t - 1) * (t * t * std::sqrt(7.) + 1)) *
+              (t + 1) * (t + 1) / (a * (-1120 + 160 * std::sqrt(7.)));
+  double w6 = 1. / 480 + 7. / 32 * t * t * t * t * t * t +
+              21. / 80 * t * t * t * t * t - 7. / 32 * t * t * t * t -
+              7. / 24 * t * t * t + 1. / 32 * t * t + 1. / 16 * t;
+  Eigen::Matrix<double, 6, 1> result;
+  result << w1, w2, w3, w4, w5, w6;
+  return result;
 }
 
 // Compute weights of the interpolating polynomial
-Eigen::Matrix<double,6,1> WKBSolver::dense_weights_derivs_6(double t){
+Eigen::Matrix<double, 6, 1> WKBSolver::dense_weights_derivs_6(double t) {
 
-    double a = std::sqrt(147+42*std::sqrt(7.));
-    double b = std::sqrt(147-42*std::sqrt(7.));
-    double c = (27783*t*t*t*t*t*t - 46305*t*t*t*t + 19845*t*t - 1323)*sqrt(7.)/16.;
-    double w1 = -(21*t*t*t*t-14*t*t+1)*(t-1)/16.;
-    double w2 = -c/(a*(-7+sqrt(7.))*(21*t + a));
-    double w3 = -c/(b*(7+sqrt(7.))*(21*t + b));
-    double w4 = c/(b*(7+sqrt(7.))*(21*t - b));
-    double w5 = c/(a*(-7+sqrt(7.))*(21*t - a));
-    double w6 = (21*t*t*t*t-14*t*t+1)*(t+1)/16.;
-    Eigen::Matrix<double,6,1> result;
-    result << w1,w2,w3,w4,w5,w6;
-    return result;
+  double a = std::sqrt(147 + 42 * std::sqrt(7.));
+  double b = std::sqrt(147 - 42 * std::sqrt(7.));
+  double c = (27783 * t * t * t * t * t * t - 46305 * t * t * t * t +
+              19845 * t * t - 1323) *
+             sqrt(7.) / 16.;
+  double w1 = -(21 * t * t * t * t - 14 * t * t + 1) * (t - 1) / 16.;
+  double w2 = -c / (a * (-7 + sqrt(7.)) * (21 * t + a));
+  double w3 = -c / (b * (7 + sqrt(7.)) * (21 * t + b));
+  double w4 = c / (b * (7 + sqrt(7.)) * (21 * t - b));
+  double w5 = c / (a * (-7 + sqrt(7.)) * (21 * t - a));
+  double w6 = (21 * t * t * t * t - 14 * t * t + 1) * (t + 1) / 16.;
+  Eigen::Matrix<double, 6, 1> result;
+  result << w1, w2, w3, w4, w5, w6;
+  return result;
 };
 
 // Dense output integration
-std::complex<double> WKBSolver::dense_integrate(const
-Eigen::Matrix<double,6,1> &denseweights6, const
-Eigen::Matrix<std::complex<double>,6,1> &integrand6){
+std::complex<double> WKBSolver::dense_integrate(
+    const Eigen::Matrix<double, 6, 1> &denseweights6,
+    const Eigen::Matrix<std::complex<double>, 6, 1> &integrand6) {
 
-    return h/2.0*denseweights6.dot(integrand6);
-} 
-
-// Dense output interpolation using Gauss-Lobatto
-std::complex<double> WKBSolver::dense_interpolate(const
-Eigen::Matrix<double,6,1> &denseweights6, const
-Eigen::Matrix<std::complex<double>,6,1> &integrand6){
-
-    Eigen::Matrix<double,6,1> mod_weights = denseweights6;
-    mod_weights(0) -= 1.0;
-    return mod_weights.dot(integrand6);
+  return h / 2.0 * denseweights6.dot(integrand6);
 }
 
+// Dense output interpolation using Gauss-Lobatto
+std::complex<double> WKBSolver::dense_interpolate(
+    const Eigen::Matrix<double, 6, 1> &denseweights6,
+    const Eigen::Matrix<std::complex<double>, 6, 1> &integrand6) {
 
-Eigen::Matrix<std::complex<double>,2,1> WKBSolver::integrate(const
-Eigen::Matrix<std::complex<double>,6,1> &integrand6, const
-Eigen::Matrix<std::complex<double>,5,1> &integrand5){
-    
-    std::complex<double> x6 = h/2.0*glws6.dot(integrand6);
-    std::complex<double> x5 = h/2.0*glws5.dot(integrand5);
-    Eigen::Matrix<std::complex<double>,2,1> result;
-    result << x6, x6-x5;
-    return result;
+  Eigen::Matrix<double, 6, 1> mod_weights = denseweights6;
+  mod_weights(0) -= 1.0;
+  return mod_weights.dot(integrand6);
+}
+
+Eigen::Matrix<std::complex<double>, 2, 1> WKBSolver::integrate(
+    const Eigen::Matrix<std::complex<double>, 6, 1> &integrand6,
+    const Eigen::Matrix<std::complex<double>, 5, 1> &integrand5) {
+
+  std::complex<double> x6 = h / 2.0 * glws6.dot(integrand6);
+  std::complex<double> x5 = h / 2.0 * glws5.dot(integrand5);
+  Eigen::Matrix<std::complex<double>, 2, 1> result;
+  result << x6, x6 - x5;
+  return result;
 };
 
-void WKBSolver::fp(){
-    fp_ = std::exp(s_.sum());
+void WKBSolver::fp() { fp_ = std::exp(s_.sum()); };
+
+void WKBSolver::fm() { fm_ = std::conj(fp_); };
+
+void WKBSolver::dfpi() { dfpi_ = dsi_.sum(); };
+
+void WKBSolver::dfmi() { dfmi_ = std::conj(dfpi_); };
+
+void WKBSolver::dfpf() { dfpf_ = dsf_.sum() * fp_; };
+
+void WKBSolver::dfmf() { dfmf_ = std::conj(dfpf_); };
+
+void WKBSolver::ddfp() { ddfp_ = dds_.sum() + std::pow(dsi_.sum(), 2); };
+
+void WKBSolver::ddfm() { ddfm_ = std::conj(ddfp_); };
+
+void WKBSolver::ap() { ap_ = (dx - x * dfmi_) / (dfpi_ - dfmi_); };
+
+void WKBSolver::am() { am_ = (dx - x * dfpi_) / (dfmi_ - dfpi_); };
+
+void WKBSolver::bp() {
+  bp_ = (ddx * dfmi_ - dx * ddfm_) / (ddfp_ * dfmi_ - ddfm_ * dfpi_);
 };
 
-void WKBSolver::fm(){
-    fm_ = std::conj(fp_); 
+void WKBSolver::bm() {
+  bm_ = (ddx * dfpi_ - dx * ddfp_) / (ddfm_ * dfpi_ - ddfp_ * dfmi_);
 };
 
-void WKBSolver::dfpi(){
-    dfpi_ = dsi_.sum();    
+void WKBSolver::dds() {
+  dds_ << std::complex<double>(0.0, 1.0) * d1w1_, 0.0, 0.0, 0.0;
 };
 
-void WKBSolver::dfmi(){
-    dfmi_ = std::conj(dfpi_);
+void WKBSolver::dsi() {
+  dsi_ << std::complex<double>(0.0, 1.0) * ws_(0), 0.0, 0.0, 0.0;
 };
 
-void WKBSolver::dfpf(){
-    dfpf_ = dsf_.sum()*fp_;    
+void WKBSolver::dsf() {
+  dsf_ << std::complex<double>(0.0, 1.0) * ws_(5), 0.0, 0.0, 0.0;
 };
 
-void WKBSolver::dfmf(){
-    dfmf_ = std::conj(dfpf_);
+void WKBSolver::s() {
+  Eigen::Matrix<std::complex<double>, 2, 1> s0;
+  s0 << std::complex<double>(0, 1) * integrate(ws_, ws5_);
+  s_ << s0(0), 0.0, 0.0, 0.0;
+  s_error << s0(1), 0.0, 0.0, 0.0;
 };
 
-void WKBSolver::ddfp(){
-    ddfp_ = dds_.sum() + std::pow(dsi_.sum(),2);
+void WKBSolver::d1w1() { d1w1_ = d1w1_w.dot(ws_) / h; };
+
+void WKBSolver::d1w2() { d1w2_ = d1w2_w.dot(ws_) / h; };
+
+void WKBSolver::d1w3() { d1w3_ = d1w3_w.dot(ws_) / h; };
+
+void WKBSolver::d1w4() { d1w4_ = d1w4_w.dot(ws_) / h; };
+
+void WKBSolver::d1w5() { d1w5_ = d1w5_w.dot(ws_) / h; };
+
+void WKBSolver::d1w6() { d1w6_ = d1w6_w.dot(ws_) / h; };
+
+void WKBSolver::d2w1() { d2w1_ = d2w1_w.dot(ws_) / (h * h); };
+
+void WKBSolver::d2w2() { d2w2_ = d2w2_w.dot(ws_) / (h * h); };
+
+void WKBSolver::d2w3() { d2w3_ = d2w3_w.dot(ws_) / (h * h); };
+
+void WKBSolver::d2w4() { d2w4_ = d2w4_w.dot(ws_) / (h * h); };
+
+void WKBSolver::d2w5() { d2w5_ = d2w5_w.dot(ws_) / (h * h); };
+
+void WKBSolver::d2w6() { d2w6_ = d2w6_w.dot(ws_) / (h * h); };
+
+void WKBSolver::d3w1() { d3w1_ = d3w1_w.dot(ws_) / (h * h * h); };
+
+void WKBSolver::d3w2() { d3w2_ = d3w2_w.dot(ws_) / (h * h * h); };
+
+void WKBSolver::d3w3() { d3w3_ = d3w3_w.dot(ws_) / (h * h * h); };
+
+void WKBSolver::d3w4() { d3w4_ = d3w4_w.dot(ws_) / (h * h * h); };
+
+void WKBSolver::d3w5() { d3w5_ = d3w5_w.dot(ws_) / (h * h * h); };
+
+void WKBSolver::d3w6() { d3w6_ = d3w6_w.dot(ws_) / (h * h * h); };
+
+void WKBSolver::d4w1() { d4w1_ = d4w1_w.dot(ws7_) / (h * h * h * h); };
+
+void WKBSolver::d1g1() { d1g1_ = d1g1_w.dot(gs_) / h; };
+
+void WKBSolver::d1g2() { d1g2_ = d1w2_w.dot(gs_) / h; };
+
+void WKBSolver::d1g3() { d1g3_ = d1w3_w.dot(gs_) / h; };
+
+void WKBSolver::d1g4() { d1g4_ = d1w4_w.dot(gs_) / h; };
+
+void WKBSolver::d1g5() { d1g5_ = d1w5_w.dot(gs_) / h; };
+
+void WKBSolver::d1g6() { d1g6_ = d1g6_w.dot(gs_) / h; };
+
+void WKBSolver::d2g1() { d2g1_ = d2g1_w.dot(gs_) / (h * h); };
+
+void WKBSolver::d2g2() { d2g2_ = d2w2_w.dot(gs_) / (h * h); };
+
+void WKBSolver::d2g3() { d2g3_ = d2w3_w.dot(gs_) / (h * h); };
+
+void WKBSolver::d2g4() { d2g4_ = d2w4_w.dot(gs_) / (h * h); };
+
+void WKBSolver::d2g5() { d2g5_ = d2w5_w.dot(gs_) / (h * h); };
+
+void WKBSolver::d2g6() { d2g6_ = d2g6_w.dot(gs_) / (h * h); };
+
+void WKBSolver::d3g1() { d3g1_ = d3g1_w.dot(gs_) / (h * h * h); };
+
+void WKBSolver::d1w2_5() { d1w2_5_ = d1w2_5_w.dot(ws5_) / h; };
+
+void WKBSolver::d1w3_5() { d1w3_5_ = d1w3_5_w.dot(ws5_) / h; };
+
+void WKBSolver::d1w4_5() { d1w4_5_ = d1w4_5_w.dot(ws5_) / h; };
+
+//////////////////////////////////
+
+class WKBSolver1 : public WKBSolver {
+private:
+  void dds();
+  void dsi();
+  void dsf();
+  void s();
+
+public:
+  WKBSolver1();
+  WKBSolver1(de_system &de_sys, int order);
 };
 
-void WKBSolver::ddfm(){
-    ddfm_ = std::conj(ddfp_);
+WKBSolver1::WKBSolver1(){};
+
+WKBSolver1::WKBSolver1(de_system &de_sys, int order)
+    : WKBSolver(de_sys, order){};
+
+void WKBSolver1::dds() {
+  dds_ << std::complex<double>(0, 1) * d1w1_,
+      1.0 / std::pow(ws_(0), 2) * std::pow(d1w1_, 2) / 2.0 -
+          1.0 / ws_(0) * d2w1_ / 2.0 - d1g1_,
+      0.0, 0.0;
 };
 
-void WKBSolver::ap(){
-    ap_ = (dx - x*dfmi_)/(dfpi_ - dfmi_);
+void WKBSolver1::dsi() {
+  dsi_ << std::complex<double>(0.0, 1.0) * ws_(0),
+      -0.5 * d1w1_ / ws_(0) - gs_(0), 0.0, 0.0;
 };
 
-void WKBSolver::am(){
-    am_ = (dx - x*dfpi_)/(dfmi_ - dfpi_);
+void WKBSolver1::dsf() {
+  dsf_ << std::complex<double>(0.0, 1.0) * ws_(5),
+      -0.5 * d1w6_ / ws_(5) - gs_(5), 0.0, 0.0;
 };
 
-void WKBSolver::bp(){
-    bp_ = (ddx*dfmi_ - dx*ddfm_)/(ddfp_*dfmi_ - ddfm_*dfpi_);
-};
-
-void WKBSolver::bm(){
-    bm_ = (ddx*dfpi_ - dx*ddfp_)/(ddfm_*dfpi_ - ddfp_*dfmi_);
-};
-
-void WKBSolver::dds(){
-    dds_ << std::complex<double>(0.0, 1.0)*d1w1_, 0.0, 0.0, 0.0;
-};
-
-void WKBSolver::dsi(){
-   dsi_ << std::complex<double>(0.0, 1.0)*ws_(0), 0.0, 0.0, 0.0;  
-};
-
-void WKBSolver::dsf(){
-   dsf_ << std::complex<double>(0.0, 1.0)*ws_(5), 0.0, 0.0, 0.0;
-};
-
-void WKBSolver::s(){
-    Eigen::Matrix<std::complex<double>,2,1> s0;
-    s0 << std::complex<double>(0,1)*integrate(ws_, ws5_);  
-    s_ << s0(0), 0.0, 0.0, 0.0;
-    s_error << s0(1), 0.0, 0.0, 0.0; 
-};
-
-void WKBSolver::d1w1(){
-    d1w1_ = d1w1_w.dot(ws_)/h;
-};
-
-void  WKBSolver::d1w2(){
-    d1w2_ = d1w2_w.dot(ws_)/h;
-};
-
-void WKBSolver::d1w3(){
-    d1w3_ = d1w3_w.dot(ws_)/h;
-};
-
-void WKBSolver::d1w4(){
-    d1w4_ = d1w4_w.dot(ws_)/h;
-};
-
-void WKBSolver::d1w5(){
-    d1w5_ = d1w5_w.dot(ws_)/h;
-};
-
-void WKBSolver::d1w6(){
-    d1w6_ = d1w6_w.dot(ws_)/h;
-};
-
-void WKBSolver::d2w1(){
-    d2w1_ = d2w1_w.dot(ws_)/(h*h);
-};
-
-void WKBSolver::d2w2(){
-    d2w2_ = d2w2_w.dot(ws_)/(h*h);
-};
-
-void WKBSolver::d2w3(){
-    d2w3_ = d2w3_w.dot(ws_)/(h*h);
-};
-
-void WKBSolver::d2w4(){
-    d2w4_ = d2w4_w.dot(ws_)/(h*h);
-};
-
-void WKBSolver::d2w5(){
-    d2w5_ = d2w5_w.dot(ws_)/(h*h);
-};
-
-void WKBSolver::d2w6(){
-    d2w6_ = d2w6_w.dot(ws_)/(h*h);
-};
-
-void WKBSolver::d3w1(){
-    d3w1_ = d3w1_w.dot(ws_)/(h*h*h);
-};
-
-void WKBSolver::d3w2(){
-    d3w2_ = d3w2_w.dot(ws_)/(h*h*h);
-};
-
-void WKBSolver::d3w3(){
-    d3w3_ = d3w3_w.dot(ws_)/(h*h*h);
-};
-
-void WKBSolver::d3w4(){
-    d3w4_ = d3w4_w.dot(ws_)/(h*h*h);
-};
-
-void WKBSolver::d3w5(){
-    d3w5_ = d3w5_w.dot(ws_)/(h*h*h);
-};
-
-void WKBSolver::d3w6(){
-    d3w6_ = d3w6_w.dot(ws_)/(h*h*h);
-};
-
-void WKBSolver::d4w1(){
-    d4w1_ =  d4w1_w.dot(ws7_)/(h*h*h*h);
-};
-
-void WKBSolver::d1g1(){
-    d1g1_ = d1g1_w.dot(gs_)/h;
-};
-
-void WKBSolver::d1g2(){
-    d1g2_ = d1w2_w.dot(gs_)/h;
-};
-
-void WKBSolver::d1g3(){
-    d1g3_ = d1w3_w.dot(gs_)/h;
-};
-
-void WKBSolver::d1g4(){
-    d1g4_ = d1w4_w.dot(gs_)/h;
-};
-
-void WKBSolver::d1g5(){
-    d1g5_ = d1w5_w.dot(gs_)/h;
-};
-
-void WKBSolver::d1g6(){
-    d1g6_ = d1g6_w.dot(gs_)/h;
-};
-
-void WKBSolver::d2g1(){
-    d2g1_ = d2g1_w.dot(gs_)/(h*h);
-};
-
-void WKBSolver::d2g2(){
-    d2g2_ = d2w2_w.dot(gs_)/(h*h);
-};
-
-void WKBSolver::d2g3(){
-    d2g3_ = d2w3_w.dot(gs_)/(h*h);
-};
-
-void WKBSolver::d2g4(){
-    d2g4_ = d2w4_w.dot(gs_)/(h*h);
-};
-
-void WKBSolver::d2g5(){
-    d2g5_ = d2w5_w.dot(gs_)/(h*h);
-};
-
-void WKBSolver::d2g6(){
-    d2g6_ = d2g6_w.dot(gs_)/(h*h);
-};
-
-void WKBSolver::d3g1(){
-    d3g1_ = d3g1_w.dot(gs_)/(h*h*h);
-};
-
-void WKBSolver::d1w2_5(){
-    d1w2_5_ = d1w2_5_w.dot(ws5_)/h;
-};
-
-void WKBSolver::d1w3_5(){
-    d1w3_5_ = d1w3_5_w.dot(ws5_)/h;
-};
-
-void WKBSolver::d1w4_5(){
-    d1w4_5_ = d1w4_5_w.dot(ws5_)/h;
+void WKBSolver1::s() {
+  Eigen::Matrix<std::complex<double>, 2, 1> s0, s1;
+  s0 << std::complex<double>(0, 1) * integrate(ws_, ws5_);
+  s1 << integrate(gs_, gs5_);
+  s1(0) = std::log(std::sqrt(ws_(0) / ws_(5))) - s1(0);
+  s_ << s0(0), s1(0), 0.0, 0.0;
+  s_error << s0(1), s1(1), 0.0, 0.0;
 };
 
 //////////////////////////////////
 
-class WKBSolver1 : public WKBSolver
-{
-    private: 
-        void dds();
-        void dsi();
-        void dsf();
-        void s();       
+class WKBSolver2 : public WKBSolver {
+private:
+  void dds();
+  void dsi();
+  void dsf();
+  void s();
 
-    public:
-        WKBSolver1();
-        WKBSolver1(de_system &de_sys, int order);
-
+public:
+  WKBSolver2();
+  WKBSolver2(de_system &de_sys, int order);
 };
 
-WKBSolver1::WKBSolver1(){
+WKBSolver2::WKBSolver2(){};
+
+WKBSolver2::WKBSolver2(de_system &de_sys, int order)
+    : WKBSolver(de_sys, order){};
+
+void WKBSolver2::dds() {
+  dds_ << std::complex<double>(0, 1) * d1w1_,
+      1.0 / std::pow(ws_(0), 2) * std::pow(d1w1_, 2) / 2.0 -
+          1.0 / ws_(0) * d2w1_ / 2.0 - d1g1_,
+      -std::complex<double>(0, 1 / 8) *
+          (8.0 * d1g1_ * gs_(0) * std::pow(ws_(0), 3) -
+           4.0 * d1w1_ * std::pow(gs_(0), 2) * std::pow(ws_(0), 2) +
+           4.0 * d2g1_ * std::pow(ws_(0), 3) -
+           4.0 * d1w1_ * d1g1_ * std::pow(ws_(0), 2) +
+           2.0 * d3w1_ * std::pow(ws_(0), 2) - 10.0 * d1w1_ * d2w1_ * ws_(0) +
+           9.0 * std::pow(d1w1_, 3)) /
+          std::pow(ws_(0), 4),
+      0.0;
 };
 
-WKBSolver1::WKBSolver1(de_system &de_sys, int order) : WKBSolver(de_sys, order){
+void WKBSolver2::dsi() {
+  dsi_ << std::complex<double>(0, 1) * ws_(0),
+      -1.0 / ws_(0) * d1w1_ / 2.0 - gs_(0),
+      std::complex<double>(0, 1 / 8) *
+          (-4.0 * std::pow(gs_(0), 2) * std::pow(ws_(0), 2) -
+           4.0 * d1g1_ * std::pow(ws_(0), 2) - 2.0 * d2w1_ * ws_(0) +
+           3.0 * std::pow(d1w1_, 2)) /
+          std::pow(ws_(0), 3),
+      0.0;
 };
 
-void WKBSolver1::dds(){
-    dds_ << std::complex<double>(0,1)*d1w1_,
-    1.0/std::pow(ws_(0),2)*std::pow(d1w1_,2)/2.0-1.0/ws_(0)*d2w1_/2.0-d1g1_, 0.0, 0.0;
+void WKBSolver2::dsf() {
+  dsf_ << std::complex<double>(0, 1) * ws_(5),
+      -1.0 / ws_(5) * d1w6_ / 2.0 - gs_(5),
+      std::complex<double>(0, 1 / 8) *
+          (-4.0 * std::pow(gs_(5), 2) * std::pow(ws_(5), 2) -
+           4.0 * d1g6_ * std::pow(ws_(5), 2) - 2.0 * d2w6_ * ws_(5) +
+           3.0 * std::pow(d1w6_, 2)) /
+          std::pow(ws_(5), 3),
+      0.0;
 };
 
-void WKBSolver1::dsi(){
-   dsi_ << std::complex<double>(0.0, 1.0)*ws_(0), -0.5*d1w1_/ws_(0)-gs_(0), 0.0, 0.0;
-};
-
-void WKBSolver1::dsf(){
-   dsf_ << std::complex<double>(0.0, 1.0)*ws_(5), -0.5*d1w6_/ws_(5)-gs_(5), 0.0, 0.0;
-};
-
-void WKBSolver1::s(){
-    Eigen::Matrix<std::complex<double>,2,1> s0, s1;
-    s0 << std::complex<double>(0,1)*integrate(ws_, ws5_);  
-    s1 << integrate(gs_, gs5_);
-    s1(0) = std::log(std::sqrt(ws_(0)/ws_(5))) - s1(0);
-    s_ << s0(0), s1(0), 0.0, 0.0;
-    s_error << s0(1), s1(1), 0.0, 0.0;
-
-};
-
-//////////////////////////////////
-
-class WKBSolver2 : public WKBSolver
-{
-    private: 
-        void dds();
-        void dsi();
-        void dsf();
-        void s();       
-
-    public:
-        WKBSolver2();
-        WKBSolver2(de_system &de_sys, int order);
-
-};
-
-WKBSolver2::WKBSolver2(){
-};
-
-WKBSolver2::WKBSolver2(de_system &de_sys, int order) : WKBSolver(de_sys, order){
-};
-
-void WKBSolver2::dds(){
-    dds_ << std::complex<double>(0,1)*d1w1_,
-    1.0/std::pow(ws_(0),2)*std::pow(d1w1_,2)/2.0-1.0/ws_(0)*d2w1_/2.0-d1g1_,
-    -std::complex<double>(0,1/8)*(8.0*d1g1_*gs_(0)*std::pow(ws_(0),3)-4.0*d1w1_*std::pow(gs_(0),2)*std::pow(ws_(0),2)+4.0*d2g1_*std::pow(ws_(0),3)-4.0*d1w1_*d1g1_*std::pow(ws_(0),2)+2.0*d3w1_*std::pow(ws_(0),2)-10.0*d1w1_*d2w1_*ws_(0)+9.0*std::pow(d1w1_,3))/std::pow(ws_(0),4), 0.0;
-};
-
-void WKBSolver2::dsi(){
-    dsi_ << std::complex<double>(0,1)*ws_(0),-1.0/ws_(0)*d1w1_/2.0-gs_(0),
-    std::complex<double>(0,1/8)*(-4.0*std::pow(gs_(0),2)*std::pow(ws_(0),2)-4.0*d1g1_*std::pow(ws_(0),2)-2.0*d2w1_
-    *ws_(0)+3.0*std::pow(d1w1_,2))/std::pow(ws_(0),3), 0.0;
-};
-
-void WKBSolver2::dsf(){
-    dsf_ << std::complex<double>(0,1)*ws_(5),-1.0/ws_(5)*d1w6_/2.0-gs_(5),
-    std::complex<double>(0,1/8)*(-4.0*std::pow(gs_(5),2)*std::pow(ws_(5),2)-4.0*d1g6_*std::pow(ws_(5),2)-2.0*d2w6_
-    *ws_(5)+3.0*std::pow(d1w6_,2))/std::pow(ws_(5),3), 0.0;
-};
-
-void WKBSolver2::s(){
-    Eigen::Matrix<std::complex<double>,2,1> s0, s1, s2;  
-    Eigen::Matrix<std::complex<double>,6,1> integrand6;
-    Eigen::Matrix<std::complex<double>,5,1> integrand5;
-    integrand6 = 4*gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
-    4*dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
-    dws_.cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
-    integrand5 =  4*gs5_.cwiseProduct(gs5_).cwiseQuotient(ws5_) +
-    4*dws5_.cwiseProduct(gs5_).cwiseQuotient(ws5_.cwiseProduct(ws5_)) +
-    dws5_.cwiseProduct(dws5_).cwiseQuotient(ws5_.cwiseProduct(ws5_.cwiseProduct(ws5_)));
-    s0 << std::complex<double>(0,1)*integrate(ws_, ws5_);  
-    s1 << integrate(gs_, gs5_);
-    s1(0) = std::log(std::sqrt(ws_(0)/ws_(5))) - s1(0);
-    s2 << integrate(integrand6, integrand5);
-    s2(0) = -1/4.0*(dws_(5)/std::pow(ws_(5),2)+2.0*gs_(5)/ws_(5)-
-        dws_(0)/std::pow(ws_(0),2)-2.0*gs_(0)/ws_(0))-1/8.0*s2(0);
-    s_ << s0(0), s1(0), std::complex<double>(0,1)*s2(0), 0.0;
-    s_error << s0(1), s1(1), std::complex<double>(0,-1/8)*s2(1), 0.0;
-
+void WKBSolver2::s() {
+  Eigen::Matrix<std::complex<double>, 2, 1> s0, s1, s2;
+  Eigen::Matrix<std::complex<double>, 6, 1> integrand6;
+  Eigen::Matrix<std::complex<double>, 5, 1> integrand5;
+  integrand6 = 4 * gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
+               4 * dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
+               dws_.cwiseProduct(dws_).cwiseQuotient(
+                   ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
+  integrand5 =
+      4 * gs5_.cwiseProduct(gs5_).cwiseQuotient(ws5_) +
+      4 * dws5_.cwiseProduct(gs5_).cwiseQuotient(ws5_.cwiseProduct(ws5_)) +
+      dws5_.cwiseProduct(dws5_).cwiseQuotient(
+          ws5_.cwiseProduct(ws5_.cwiseProduct(ws5_)));
+  s0 << std::complex<double>(0, 1) * integrate(ws_, ws5_);
+  s1 << integrate(gs_, gs5_);
+  s1(0) = std::log(std::sqrt(ws_(0) / ws_(5))) - s1(0);
+  s2 << integrate(integrand6, integrand5);
+  s2(0) = -1 / 4.0 *
+              (dws_(5) / std::pow(ws_(5), 2) + 2.0 * gs_(5) / ws_(5) -
+               dws_(0) / std::pow(ws_(0), 2) - 2.0 * gs_(0) / ws_(0)) -
+          1 / 8.0 * s2(0);
+  s_ << s0(0), s1(0), std::complex<double>(0, 1) * s2(0), 0.0;
+  s_error << s0(1), s1(1), std::complex<double>(0, -1 / 8) * s2(1), 0.0;
 };
 
 //////////////////////////////////
 
-class WKBSolver3 : public WKBSolver
-{
-    private: 
-        void dds();
-        void dsi();
-        void dsf();
-        void s();       
+class WKBSolver3 : public WKBSolver {
+private:
+  void dds();
+  void dsi();
+  void dsf();
+  void s();
 
-    public:
-        WKBSolver3();
-        WKBSolver3(de_system &de_sys, int);
-
+public:
+  WKBSolver3();
+  WKBSolver3(de_system &de_sys, int);
 };
 
-WKBSolver3::WKBSolver3(){
+WKBSolver3::WKBSolver3(){};
+
+WKBSolver3::WKBSolver3(de_system &de_sys, int order)
+    : WKBSolver(de_sys, order){};
+
+void WKBSolver3::dds() {
+  dds_ << std::complex<double>(0, 1) * d1w1_,
+      1.0 / (ws_(0) * ws_(0)) * (d1w1_ * d1w1_) / 2.0 -
+          1.0 / ws_(0) * d2w1_ / 2.0 - d1g1_,
+      -std::complex<double>(0, 1.0 / 8.0) *
+          (8.0 * d1g1_ * gs_(0) * (ws_(0) * ws_(0) * ws_(0)) -
+           4.0 * d1w1_ * (gs_(0) * gs_(0)) * ws_(0) * ws_(0) +
+           4.0 * d2g1_ * (ws_(0) * ws_(0) * ws_(0)) -
+           4.0 * d1w1_ * d1g1_ * ws_(0) * ws_(0) +
+           2.0 * d3w1_ * ws_(0) * ws_(0) - 10.0 * d1w1_ * d2w1_ * ws_(0) +
+           9.0 * (d1w1_ * d1w1_ * d1w1_)) /
+          (ws_(0) * ws_(0) * ws_(0) * ws_(0)),
+      (d4w1_ * (ws_(0) * ws_(0) * ws_(0)) +
+       2.0 * d3g1_ * (ws_(0) * ws_(0) * ws_(0) * ws_(0)) -
+       9.0 * d1w1_ * d3w1_ * ws_(0) * ws_(0) -
+       6.0 * (d2w1_ * d2w1_) * ws_(0) * ws_(0) +
+       (42.0 * ws_(0) * (d1w1_ * d1w1_) -
+        4.0 * (ws_(0) * ws_(0) * ws_(0)) * ((gs_(0) * gs_(0)) + d1g1_)) *
+           d2w1_ +
+       (4.0 * gs_(0) * (ws_(0) * ws_(0) * ws_(0) * ws_(0)) -
+        8.0 * (ws_(0) * ws_(0) * ws_(0)) * d1w1_) *
+           d2g1_ -
+       30.0 * (d1w1_ * d1w1_ * d1w1_ * d1w1_) +
+       12.0 * ws_(0) * ws_(0) * ((gs_(0) * gs_(0)) + d1g1_) * (d1w1_ * d1w1_) -
+       16.0 * d1w1_ * d1g1_ * gs_(0) * (ws_(0) * ws_(0) * ws_(0)) +
+       4.0 * (d1g1_ * d1g1_) * (ws_(0) * ws_(0) * ws_(0) * ws_(0))) /
+          (ws_(0) * ws_(0) * ws_(0) * ws_(0) * ws_(0) * ws_(0)) / 8.0;
 };
 
-WKBSolver3::WKBSolver3(de_system &de_sys, int order) : WKBSolver(de_sys, order){
+void WKBSolver3::dsi() {
+  dsi_ << std::complex<double>(0, 1) * ws_(0),
+      -1.0 / ws_(0) * d1w1_ / 2.0 - gs_(0),
+      std::complex<double>(0, 1.0 / 8.0) *
+          (-4.0 * (gs_(0) * gs_(0)) * ws_(0) * ws_(0) -
+           4.0 * d1g1_ * ws_(0) * ws_(0) - 2.0 * d2w1_ * ws_(0) +
+           3.0 * (d1w1_ * d1w1_)) /
+          (ws_(0) * ws_(0) * ws_(0)),
+      (d3w1_ * ws_(0) * ws_(0) + 2.0 * d2g1_ * (ws_(0) * ws_(0) * ws_(0)) -
+       6.0 * d1w1_ * d2w1_ * ws_(0) + 6.0 * (d1w1_ * d1w1_ * d1w1_) -
+       4.0 * ((gs_(0) * gs_(0)) + d1g1_) * ws_(0) * ws_(0) * d1w1_ +
+       4.0 * d1g1_ * gs_(0) * (ws_(0) * ws_(0) * ws_(0))) /
+          (ws_(0) * ws_(0) * ws_(0) * ws_(0) * ws_(0)) / 8.0;
 };
 
-void WKBSolver3::dds(){
-    dds_ << std::complex<double>(0,1)*d1w1_,
-    1.0/(ws_(0)*ws_(0))*(d1w1_*d1w1_)/2.0-1.0/ws_(0)*d2w1_/2.0-d1g1_,
-    -std::complex<double>(0,1.0/8.0)*(8.0*d1g1_*gs_(0)*(ws_(0)*ws_(0)*ws_(0))-4.0*d1w1_*(gs_(0)*gs_(0))*ws_(0)*ws_(0)+4.0*d2g1_*(ws_(0)*ws_(0)*ws_(0))-4.0*d1w1_*d1g1_*ws_(0)*ws_(0)+2.0*d3w1_*ws_(0)*ws_(0)-10.0*d1w1_*d2w1_*ws_(0)+9.0*(d1w1_*d1w1_*d1w1_))/(ws_(0)*ws_(0)*ws_(0)*ws_(0)),
-    (d4w1_*(ws_(0)*ws_(0)*ws_(0))+2.0*d3g1_*(ws_(0)*ws_(0)*ws_(0)*ws_(0))-9.0*d1w1_*d3w1_*ws_(0)*ws_(0)-6.0*(d2w1_*d2w1_)*ws_(0)*ws_(0) + (42.0*ws_(0)*(d1w1_*d1w1_)-4.0*(ws_(0)*ws_(0)*ws_(0))*((gs_(0)*gs_(0))+d1g1_))*d2w1_+(4.0*gs_(0)*(ws_(0)*ws_(0)*ws_(0)*ws_(0))-8.0*(ws_(0)*ws_(0)*ws_(0))*d1w1_)*d2g1_-30.0*(d1w1_*d1w1_*d1w1_*d1w1_)+12.0*ws_(0)*ws_(0)*((gs_(0)*gs_(0))+d1g1_)*(d1w1_*d1w1_)-16.0*d1w1_*d1g1_*gs_(0)*(ws_(0)*ws_(0)*ws_(0))+4.0*(d1g1_*d1g1_)*(ws_(0)*ws_(0)*ws_(0)*ws_(0)))/(ws_(0)*ws_(0)*ws_(0)*ws_(0)*ws_(0)*ws_(0))/8.0;
+void WKBSolver3::dsf() {
+  dsf_ << std::complex<double>(0, 1) * ws_(5),
+      -1.0 / ws_(5) * d1w6_ / 2.0 - gs_(5),
+      std::complex<double>(0, 1.0 / 8.0) *
+          (-4.0 * (gs_(5) * gs_(5)) * (ws_(5) * ws_(5)) -
+           4.0 * d1g6_ * (ws_(5) * ws_(5)) - 2.0 * d2w6_ * ws_(5) +
+           3.0 * (d1w6_ * d1w6_)) /
+          (ws_(5) * ws_(5) * ws_(5)),
+      (d3w6_ * (ws_(5) * ws_(5)) + 2.0 * d2g6_ * (ws_(5) * ws_(5) * ws_(5)) -
+       6.0 * d1w6_ * d2w6_ * ws_(5) + 6.0 * (d1w6_ * d1w6_ * d1w6_) -
+       4.0 * ((gs_(5) * gs_(5)) + d1g6_) * (ws_(5) * ws_(5)) * d1w6_ +
+       4.0 * d1g6_ * gs_(5) * (ws_(5) * ws_(5) * ws_(5))) /
+          (ws_(5) * ws_(5) * ws_(5) * ws_(5) * ws_(5)) / 8.0;
 };
 
-void WKBSolver3::dsi(){
-    dsi_ << std::complex<double>(0,1)*ws_(0),-1.0/ws_(0)*d1w1_/2.0-gs_(0),
-    std::complex<double>(0,1.0/8.0)*(-4.0*(gs_(0)*gs_(0))*ws_(0)*ws_(0)-4.0*d1g1_*ws_(0)*ws_(0)-2.0*d2w1_
-    *ws_(0)+3.0*(d1w1_*d1w1_))/(ws_(0)*ws_(0)*ws_(0)) ,
-    (d3w1_*ws_(0)*ws_(0)+2.0*d2g1_*(ws_(0)*ws_(0)*ws_(0))-6.0*d1w1_*d2w1_*ws_(0)+
-    6.0*(d1w1_*d1w1_*d1w1_)-4.0*((gs_(0)*gs_(0))+d1g1_)*ws_(0)*ws_(0)*d1w1_+4.0*d1g1_
-    *gs_(0)*(ws_(0)*ws_(0)*ws_(0)))/(ws_(0)*ws_(0)*ws_(0)*ws_(0)*ws_(0))/8.0;
+void WKBSolver3::s() {
+  Eigen::Matrix<std::complex<double>, 2, 1> s0, s1, s2;
+  Eigen::Matrix<std::complex<double>, 6, 1> integrand6;
+  Eigen::Matrix<std::complex<double>, 5, 1> integrand5;
+  integrand6 =
+      4.0 * gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
+      4.0 * dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
+      dws_.cwiseProduct(dws_).cwiseQuotient(
+          ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
+  integrand5 =
+      4.0 * gs5_.cwiseProduct(gs5_).cwiseQuotient(ws5_) +
+      4.0 * dws5_.cwiseProduct(gs5_).cwiseQuotient(ws5_.cwiseProduct(ws5_)) +
+      dws5_.cwiseProduct(dws5_).cwiseQuotient(
+          ws5_.cwiseProduct(ws5_.cwiseProduct(ws5_)));
+  s0 << std::complex<double>(0, 1) * integrate(ws_, ws5_);
+  s1 << integrate(gs_, gs5_);
+  s1(0) = std::log(std::sqrt(ws_(0) / ws_(5))) - s1(0);
+  s2 << integrate(integrand6, integrand5);
+  s2(0) = -1 / 4.0 *
+              (dws_(5) / (ws_(5) * ws_(5)) + 2.0 * gs_(5) / ws_(5) -
+               dws_(0) / (ws_(0) * ws_(0)) - 2.0 * gs_(0) / ws_(0)) -
+          1 / 8.0 * s2(0);
+  std::complex<double> s3 =
+      (1 / 4.0 *
+           (gs_(5) * gs_(5) / (ws_(5) * ws_(5)) -
+            gs_(0) * gs_(0) / (ws_(0) * ws_(0))) +
+       1 / 4.0 * (d1g6_ / (ws_(5) * ws_(5)) - d1g1_ / (ws_(0) * ws_(0))) -
+       3 / 16.0 *
+           (dws_(5) * dws_(5) / (ws_(5) * ws_(5) * ws_(5) * ws_(5)) -
+            dws_(0) * dws_(0) / (ws_(0) * ws_(0) * ws_(0) * ws_(0))) +
+       1 / 8.0 *
+           (d2w6_ / (ws_(5) * ws_(5) * ws_(5)) -
+            d2w1_ / (ws_(0) * ws_(0) * ws_(0))));
+  s_ << s0(0), s1(0), std::complex<double>(0, 1) * s2(0), s3;
+  s_error << s0(1), s1(1), std::complex<double>(0, -1.0 / 8.0) * s2(1), 0.0;
 };
-
-void WKBSolver3::dsf(){
-    dsf_ << std::complex<double>(0,1)*ws_(5),-1.0/ws_(5)*d1w6_/2.0-gs_(5),
-    std::complex<double>(0,1.0/8.0)*(-4.0*(gs_(5)*gs_(5))*(ws_(5)*ws_(5))-4.0*d1g6_*(ws_(5)*ws_(5))-2.0*d2w6_
-    *ws_(5)+3.0*(d1w6_*d1w6_))/(ws_(5)*ws_(5)*ws_(5)) ,
-    (d3w6_*(ws_(5)*ws_(5))+2.0*d2g6_*(ws_(5)*ws_(5)*ws_(5))-6.0*d1w6_*d2w6_*ws_(5)+
-    6.0*(d1w6_*d1w6_*d1w6_)-4.0*((gs_(5)*gs_(5))+d1g6_)*(ws_(5)*ws_(5))*d1w6_+4.0*d1g6_
-    *gs_(5)*(ws_(5)*ws_(5)*ws_(5)))/(ws_(5)*ws_(5)*ws_(5)*ws_(5)*ws_(5))/8.0;
-};
-
-void WKBSolver3::s(){
-    Eigen::Matrix<std::complex<double>,2,1> s0, s1, s2;  
-    Eigen::Matrix<std::complex<double>,6,1> integrand6;
-    Eigen::Matrix<std::complex<double>,5,1> integrand5;
-    integrand6 = 4.0*gs_.cwiseProduct(gs_).cwiseQuotient(ws_) +
-    4.0*dws_.cwiseProduct(gs_).cwiseQuotient(ws_.cwiseProduct(ws_)) +
-    dws_.cwiseProduct(dws_).cwiseQuotient(ws_.cwiseProduct(ws_.cwiseProduct(ws_)));
-    integrand5 =  4.0*gs5_.cwiseProduct(gs5_).cwiseQuotient(ws5_) +
-    4.0*dws5_.cwiseProduct(gs5_).cwiseQuotient(ws5_.cwiseProduct(ws5_)) +
-    dws5_.cwiseProduct(dws5_).cwiseQuotient(ws5_.cwiseProduct(ws5_.cwiseProduct(ws5_)));
-    s0 << std::complex<double>(0,1)*integrate(ws_, ws5_);  
-    s1 << integrate(gs_, gs5_);
-    s1(0) = std::log(std::sqrt(ws_(0)/ws_(5))) - s1(0);
-    s2 << integrate(integrand6, integrand5);
-    s2(0) = -1/4.0*(dws_(5)/(ws_(5)*ws_(5))+2.0*gs_(5)/ws_(5)-
-        dws_(0)/(ws_(0)*ws_(0))-2.0*gs_(0)/ws_(0))-1/8.0*s2(0);
-    std::complex<double> s3 = (1/4.0*(gs_(5)*gs_(5)/(ws_(5)*ws_(5)) -
-    gs_(0)*gs_(0)/(ws_(0)*ws_(0))) + 1/4.0*(d1g6_/(ws_(5)*ws_(5)) -
-    d1g1_/(ws_(0)*ws_(0)))-3/16.0*(dws_(5)*dws_(5)/(ws_(5)*ws_(5)*ws_(5)*ws_(5)) -
-    dws_(0)*dws_(0)/(ws_(0)*ws_(0)*ws_(0)*ws_(0))) + 1/8.0*(d2w6_/(ws_(5)*ws_(5)*ws_(5)) -
-    d2w1_/(ws_(0)*ws_(0)*ws_(0))));
-    s_ << s0(0), s1(0), std::complex<double>(0,1)*s2(0), s3;
-    s_error << s0(1), s1(1), std::complex<double>(0,-1.0/8.0)*s2(1), 0.0;
-};
-


### PR DESCRIPTION
# Description

Runs clang-format over the source code. This can be replicated as 

```
clang-format -i ./include/interpolator.hpp ./include/rksolver.hpp ./include/solver.hpp ./include/system.hpp ./include/wkbsolver.hpp
```

One non-replicatable change from this is the include headers. Some of the headers were missing includes for `<list>` and `<complex>` etc. and would not compile locally for me so I just updated them to include those headers

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (`pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Update version number (Should an aesthetic change bump up the version number? I have no idea but happy to bump it up to 1.1.2.1)
